### PR TITLE
v1.1 → v2.0

### DIFF
--- a/src/TachiDesk/Common.ts
+++ b/src/TachiDesk/Common.ts
@@ -63,7 +63,7 @@ export const DEFAULT_SERVER_CATEGORY: tachiCategory = {
 export const DEFAULT_SERVER_CATEGORIES: Record<string, tachiCategory> = { "0": DEFAULT_SERVER_CATEGORY };
 export const DEFAULT_SELECTED_CATEGORIES = ["0"];
 
-export const DEFAULT_SERVER_SOURCE : tachiSources = {
+export const DEFAULT_SERVER_SOURCE: tachiSources = {
     id: "0",
     name: "Local source",
     lang: "localsourcelang",
@@ -228,6 +228,7 @@ export async function resetSettings(stateManager: SourceStateManager) {
     await stateManager.store(UPDATED_ROW_STYLE_KEY, DEFAULT_UPDATED_ROW_STYLE)
     await stateManager.store(CATEGORY_ROW_STYLE_KEY, DEFAULT_CATEGORY_ROW_STYLE)
     await stateManager.store(SOURCE_ROW_STYLE_KEY, DEFAULT_SOURCE_ROW_STYLE)
+    await stateManager.store(SELECTED_LANGUAGES_KEY, DEFAULT_SELECTED_LANGUAGES)
 }
 // ! Reset Settings End
 
@@ -526,15 +527,16 @@ export async function getSourceRowStyle(stateManager: SourceStateManager) {
 }
 // ! Homepage Settings End
 
-export async function getServerLanguages(stateManager : SourceStateManager){
+// ! Languages Settings Start
+export async function getServerLanguages(stateManager: SourceStateManager) {
     const serverSources = await getServerSources(stateManager)
     const serverLanguages = Object.values(serverSources).map((source) => source.lang)
     const languages = getLanguageCodes()
 
     let missedLanguages = []
 
-    for (const language of serverLanguages){
-        if(!(languages.includes(language))){
+    for (const language of serverLanguages) {
+        if (!(languages.includes(language))) {
             missedLanguages.push(language)
         }
     }
@@ -542,18 +544,38 @@ export async function getServerLanguages(stateManager : SourceStateManager){
     return missedLanguages
 }
 
-export function getLanguageCodes(){
+export function getLanguageCodes() {
     return Object.keys(languages)
 }
 
-export function getLanguageName(languageCode : string) : string{
+export function getLanguageName(languageCode: string): string {
     return languages[languageCode] ?? languageCode
 }
 
-export async function setSelectedLanguages(stateManager: SourceStateManager, languages: string[]){
+export async function setSelectedLanguages(stateManager: SourceStateManager, languages: string[]) {
     await stateManager.store(SELECTED_LANGUAGES_KEY, languages)
 }
 
-export async function getSelectedLanguages(stateManager: SourceStateManager){
+export async function getSelectedLanguages(stateManager: SourceStateManager) {
     return (await stateManager.retrieve(SELECTED_LANGUAGES_KEY) as string[] | undefined) ?? DEFAULT_SELECTED_LANGUAGES
+}
+// ! Languages settings end
+
+export async function v1Migration(stateManager: SourceStateManager) {
+    const serverAddress = await stateManager.retrieve("server_address")
+    const selectedCategories = await stateManager.retrieve("selected_category")
+    const selectedSources = await stateManager.retrieve("selected_sources")
+
+    if (serverAddress) {
+        await setServerURL(stateManager, serverAddress)
+        await stateManager.store("server_address", undefined)
+    }
+    if (selectedCategories) {
+        await stateManager.store("selected_category", undefined)
+        await setSelectedCategories(stateManager, selectedCategories)
+    }
+    if (selectedSources) {
+        await stateManager.store("selected_sources", undefined)
+        await setSelectedSources(stateManager, selectedSources)
+    }
 }

--- a/src/TachiDesk/Common.ts
+++ b/src/TachiDesk/Common.ts
@@ -53,7 +53,7 @@ export class TachiAPIClass {
             data,
             headers
         });
-        console.log(JSON.stringify([request.url,request.headers,request.param ?? "", request.method, request.data, request.headers]))
+
         let response;
         let responseStatus;
         let responseData;
@@ -101,7 +101,6 @@ export class TachiCategoriesClass {
     DEFAULT_API_ENDPOINT = "/category/"
 
     allCategories = this.DEFAULT_CATEGORIES;
-    allCategoriesOrder = [0]
 
     selectedCategories = Object.keys(this.allCategories);
 
@@ -119,7 +118,6 @@ export class TachiCategoriesClass {
 
         for (const category of requestedCategories) {
             this.allCategories[category.id] = category.name;
-            this.allCategoriesOrder.push(category.id)
         }
 
         return this;
@@ -130,9 +128,6 @@ export class TachiCategoriesClass {
         return this.allCategories
     };
 
-    getAllCategoryIdsInOrder = () => {
-        return this.allCategoriesOrder
-    }
 
     getSelectedCategories = async (stateManager: SourceStateManager) => {
         return await stateManager.retrieve(this.selectedCategoryKey) ?? this.selectedCategories;

--- a/src/TachiDesk/Common.ts
+++ b/src/TachiDesk/Common.ts
@@ -57,7 +57,7 @@ export class TachiAPIClass {
         let response;
         let responseStatus;
         let responseData;
-        
+
         try {
             response = await requestManager.schedule(request, 0);
         }
@@ -101,7 +101,6 @@ export class TachiCategoriesClass {
     DEFAULT_API_ENDPOINT = "/category/"
 
     allCategories = this.DEFAULT_CATEGORIES;
-
     selectedCategories = Object.keys(this.allCategories);
 
     selectedCategoryKey = "selected_category"
@@ -127,7 +126,6 @@ export class TachiCategoriesClass {
     getAllCategories = () => {
         return this.allCategories
     };
-
 
     getSelectedCategories = async (stateManager: SourceStateManager) => {
         return await stateManager.retrieve(this.selectedCategoryKey) ?? this.selectedCategories;

--- a/src/TachiDesk/Common.ts
+++ b/src/TachiDesk/Common.ts
@@ -101,6 +101,8 @@ export class TachiCategoriesClass {
     DEFAULT_API_ENDPOINT = "/category/"
 
     allCategories = this.DEFAULT_CATEGORIES;
+    allCategoriesOrder = [0]
+
     selectedCategories = Object.keys(this.allCategories);
 
     selectedCategoryKey = "selected_category"
@@ -117,6 +119,7 @@ export class TachiCategoriesClass {
 
         for (const category of requestedCategories) {
             this.allCategories[category.id] = category.name;
+            this.allCategoriesOrder.push(category.id)
         }
 
         return this;
@@ -126,6 +129,10 @@ export class TachiCategoriesClass {
     getAllCategories = () => {
         return this.allCategories
     };
+
+    getAllCategoryIdsInOrder = () => {
+        return this.allCategoriesOrder
+    }
 
     getSelectedCategories = async (stateManager: SourceStateManager) => {
         return await stateManager.retrieve(this.selectedCategoryKey) ?? this.selectedCategories;

--- a/src/TachiDesk/Common.ts
+++ b/src/TachiDesk/Common.ts
@@ -1,5 +1,4 @@
 import {
-    HomeSectionType,
     RequestManager,
     SourceStateManager
 } from '@paperback/types'
@@ -15,46 +14,6 @@ export function serverUnavailableMangaTiles() {
     ]
 }
 
-// Defaults
-export const DEFAULT_SERVER_URL = "http://127.0.0.1:4567/";
-export const DEFAULT_API_ENDPOINT = "api/v1/";
-export const DEFAULT_SERVER_API = DEFAULT_SERVER_URL + DEFAULT_API_ENDPOINT;
-export const DEFAULT_AUTH_STATE = false;
-export const DEFAULT_AUTH_STRING = "";
-export const DEFAULT_USERNAME = "";
-export const DEFAULT_PASSWORD = "";
-
-export const DEFAULT_SERVER_CATEGORIES: Record<string, tachiCategory> = {
-    "0": {
-        id: 0,
-        order: 0,
-        name: "Default",
-        default: true,
-        size: 0,
-        includeInUpdate: "EXCLUDE",
-        meta: {
-            "additionalProp1": "string",
-            "additionalProp2": "string",
-            "additionalProp3": "string"
-        }
-    }
-};
-export const DEFAULT_SELECTED_CATEGORIES = ["0"];
-
-export const DEFAULT_SERVER_SOURCES: Record<string, tachiSources> = {
-    "0": {
-        id: "0",
-        name: "Local source",
-        lang: "localsourcelang",
-        iconUrl: "/api/v1/extension/icon/localSource",
-        supportsLatest: true,
-        isConfigurable: false,
-        isNsfw: false,
-        displayName: "Local source"
-    }
-}
-export const DEFAULT_SELECTED_SOURCES = ["0"]
-
 // StateManager Keys
 export const SERVER_URL_KEY = "serverURL";
 export const SERVER_API_KEY = "serverAPI";
@@ -68,6 +27,63 @@ export const SELECTED_CATEGORIES_KEY = "selectedCategories";
 
 export const SERVER_SOURCES_KEY = "serverSources";
 export const SELECTED_SOURCES_KEY = "selectedSources";
+
+export const MANGA_PER_ROW_KEY = "mangaPerRow"
+export const UPDATED_ROW_STATE_KEY = "updatedRowState"
+export const CATEGORY_ROW_STATE_KEY = "categoryRowState"
+export const SOURCE_ROW_STATE_KEY = "sourceRowState"
+export const UPDATED_ROW_STYLE_KEY = "updatedRowStyle"
+export const CATEGORY_ROW_STYLE_KEY = "categoryRowStyle"
+export const SOURCE_ROW_STYLE_KEY = "sourceRowStyle"
+
+// Defaults
+export const DEFAULT_SERVER_URL = "http://127.0.0.1:4567/";
+export const DEFAULT_API_ENDPOINT = "api/v1/";
+export const DEFAULT_SERVER_API = DEFAULT_SERVER_URL + DEFAULT_API_ENDPOINT;
+export const DEFAULT_AUTH_STATE = false;
+export const DEFAULT_AUTH_STRING = "";
+export const DEFAULT_USERNAME = "";
+export const DEFAULT_PASSWORD = "";
+
+export const DEFAULT_SERVER_CATEGORY: tachiCategory = {
+    id: 0,
+    order: 0,
+    name: "Default",
+    default: true,
+    size: 0,
+    includeInUpdate: "EXCLUDE",
+    meta: {
+        "additionalProp1": "string",
+        "additionalProp2": "string",
+        "additionalProp3": "string"
+    }
+}
+export const DEFAULT_SERVER_CATEGORIES: Record<string, tachiCategory> = { "0": DEFAULT_SERVER_CATEGORY };
+export const DEFAULT_SELECTED_CATEGORIES = ["0"];
+
+export const DEFAULT_SERVER_SOURCE : tachiSources = {
+    id: "0",
+    name: "Local source",
+    lang: "localsourcelang",
+    iconUrl: "/api/v1/extension/icon/localSource",
+    supportsLatest: true,
+    isConfigurable: false,
+    isNsfw: false,
+    displayName: "Local source"
+}
+export const DEFAULT_SERVER_SOURCES: Record<string, tachiSources> = {
+    "0": DEFAULT_SERVER_SOURCE
+}
+export const DEFAULT_SELECTED_SOURCES = ["0"]
+
+export const DEFAULT_MANGA_PER_ROW = 10;
+export const DEFAULT_UPDATED_ROW_STATE = true
+export const DEFAULT_CATEGORY_ROW_STATE = true
+export const DEFAULT_SOURCE_ROW_STATE = true
+export const DEFAULT_UPDATED_ROW_STYLE = ["singleRowNormal"]
+export const DEFAULT_CATEGORY_ROW_STYLE = ["singleRowNormal"]
+export const DEFAULT_SOURCE_ROW_STYLE = ["singleRowNormal"]
+export const rowStyles = ["singleRowNormal", "singleRowLarge", "featured", "doubleRow"]
 
 // ! Query Interfaces Start
 // interface categories
@@ -158,32 +174,25 @@ export async function resetSettings(stateManager: SourceStateManager) {
     await stateManager.store(SELECTED_CATEGORIES_KEY, DEFAULT_SELECTED_CATEGORIES)
     await stateManager.store(SERVER_SOURCES_KEY, DEFAULT_SERVER_SOURCES)
     await stateManager.store(SELECTED_SOURCES_KEY, DEFAULT_SELECTED_SOURCES)
-    await stateManager.store(MANGA_PER_ROW_KEY,DEFAULT_MANGA_PER_ROW)
-    await stateManager.store(UPDATED_ROW_STATE_KEY,DEFAULT_UPDATED_ROW_STATE)
-    await stateManager.store(CATEGORY_ROW_STATE_KEY,DEFAULT_CATEGORY_ROW_STATE)
-    await stateManager.store(SOURCE_ROW_STATE_KEY,DEFAULT_SOURCE_ROW_STATE)
-    await stateManager.store(UPDATED_ROW_STYLE_KEY,DEFAULT_UPDATED_ROW_STYLE)
-    await stateManager.store(CATEGORY_ROW_STYLE_KEY,DEFAULT_CATEGORY_ROW_STYLE)
-    await stateManager.store(SOURCE_ROW_STYLE_KEY,DEFAULT_SOURCE_ROW_STYLE)
+    await stateManager.store(MANGA_PER_ROW_KEY, DEFAULT_MANGA_PER_ROW)
+    await stateManager.store(UPDATED_ROW_STATE_KEY, DEFAULT_UPDATED_ROW_STATE)
+    await stateManager.store(CATEGORY_ROW_STATE_KEY, DEFAULT_CATEGORY_ROW_STATE)
+    await stateManager.store(SOURCE_ROW_STATE_KEY, DEFAULT_SOURCE_ROW_STATE)
+    await stateManager.store(UPDATED_ROW_STYLE_KEY, DEFAULT_UPDATED_ROW_STYLE)
+    await stateManager.store(CATEGORY_ROW_STYLE_KEY, DEFAULT_CATEGORY_ROW_STYLE)
+    await stateManager.store(SOURCE_ROW_STYLE_KEY, DEFAULT_SOURCE_ROW_STYLE)
 }
 // ! Reset Settings End
 
 // ! Server URL start
 
-// Clean server URL
-export function cleanServerURL(url: String) {
-    // If last character isn't a /, then add it to the url
-    return url.slice(-1) === '/' ? url : url + "/"
-}
-
-// Set server URL
 export async function setServerURL(stateManager: SourceStateManager, url: String) {
     url = url == "" ? DEFAULT_SERVER_URL : url
-    await stateManager.store(SERVER_URL_KEY, cleanServerURL(url))
-    await stateManager.store(SERVER_API_KEY, cleanServerURL(url) + DEFAULT_API_ENDPOINT)
+    url = url.slice(-1) === '/' ? url : url + "/" // Verified / at the end of URL
+    await stateManager.store(SERVER_URL_KEY, url)
+    await stateManager.store(SERVER_API_KEY, url + DEFAULT_API_ENDPOINT)
 }
 
-// get server URL
 export async function getServerURL(stateManager: SourceStateManager) {
     return (await stateManager.retrieve(SERVER_URL_KEY) as string | undefined) ?? DEFAULT_SERVER_URL
 }
@@ -192,63 +201,49 @@ export async function getServerURL(stateManager: SourceStateManager) {
 export async function getServerAPI(stateManager: SourceStateManager) {
     return (await stateManager.retrieve(SERVER_API_KEY) as string | undefined) ?? DEFAULT_SERVER_API
 }
-
 // !Server URL End
 
 // ! Authentication start
-
-// Set AuthState
 export async function setAuthState(stateManager: SourceStateManager, state: boolean) {
     await stateManager.store(AUTH_STATE_KEY, state)
 }
 
-// Get AuthState
 export async function getAuthState(stateManager: SourceStateManager) {
     return (await stateManager.retrieve(AUTH_STATE_KEY) as boolean | undefined) ?? DEFAULT_AUTH_STATE
 }
 
-// Set Auth String
 export async function setAuthString(stateManager: SourceStateManager) {
     let username = await getUsername(stateManager);
     let password = await getPassword(stateManager);
 
-    let authString = 'Basic ' + Buffer.from(username + ':' + password, 'binary').toString('base64');
-
+    let authString = 'Basic ' + Buffer.from(username + ':' + password, 'binary').toString('base64'); // Base64 of username:password
     await stateManager.keychain.store(AUTH_STRING_KEY, authString);
 }
 
-// Get Auth String
 export async function getAuthString(stateManager: SourceStateManager) {
     return (await stateManager.keychain.retrieve(AUTH_STRING_KEY) as string | undefined) ?? DEFAULT_AUTH_STRING;
 }
 
-// Set Username
 export async function setUsername(stateManager: SourceStateManager, username: string) {
     await stateManager.store(USERNAME_KEY, username);
-    await setAuthString(stateManager)
+    await setAuthString(stateManager) // Set new auth string based on new username
 }
 
-// Get Username
 export async function getUsername(stateManager: SourceStateManager) {
     return (await stateManager.retrieve(USERNAME_KEY) as string | undefined) ?? DEFAULT_USERNAME;
 }
 
-// Set Password
 export async function setPassword(stateManager: SourceStateManager, password: string) {
     await stateManager.keychain.store(PASSWORD_KEY, password);
-    await setAuthString(stateManager);
+    await setAuthString(stateManager); // Set new auth string based on new username
 }
 
-// Get Password
 export async function getPassword(stateManager: SourceStateManager) {
     return (await stateManager.keychain.retrieve(PASSWORD_KEY) as string | undefined) ?? DEFAULT_PASSWORD;
 }
-
 // ! Authentication End
 
 // ! Requests
-
-// Make Request
 export async function makeRequest(stateManager: SourceStateManager, requestManager: RequestManager, apiEndpoint: string, method = "GET", data: Record<string, string> = {}, headers: Record<string, string> = {}) {
     const serverAPI = await getServerAPI(stateManager)
     const authEnabled = await getAuthState(stateManager);
@@ -267,6 +262,7 @@ export async function makeRequest(stateManager: SourceStateManager, requestManag
     let responseStatus;
     let responseData;
 
+    // Checks if the request actually went out
     try {
         response = await requestManager.schedule(request, 0);
     }
@@ -274,6 +270,7 @@ export async function makeRequest(stateManager: SourceStateManager, requestManag
         return new Error(serverAPI + apiEndpoint)
     }
 
+    // Checks if we got a response, then checks if we got a good response
     try {
         responseStatus = response?.status
     }
@@ -288,6 +285,7 @@ export async function makeRequest(stateManager: SourceStateManager, requestManag
         return Error("Your query is invalid. " + JSON.stringify(response?.status))
     }
 
+    // Checks for garbage data
     try {
         responseData = JSON.parse(response.data ?? "")
     }
@@ -298,22 +296,18 @@ export async function makeRequest(stateManager: SourceStateManager, requestManag
     return responseData
 }
 
-// Test Request
+// Requests used for the test server button. Could be useful to test connection at other points
 export async function testRequest(stateManager: SourceStateManager, requestManager: RequestManager) {
     return await makeRequest(stateManager, requestManager, "settings/about/")
 }
-
 // ! Requests End
 
-
-
 // ! Categories Start
-// Fetch Categories -- get with a fetch
+// Fetch Categories from server and returns them as an object
 export async function fetchServerCategories(stateManager: SourceStateManager, requestManager: RequestManager) {
     let categories: Record<string, tachiCategory> = {};
 
     const fetchedCategories = await makeRequest(stateManager, requestManager, "category/");
-
     fetchedCategories.forEach((category: tachiCategory) => {
         categories[JSON.stringify(category.id)] = category
     });
@@ -321,54 +315,37 @@ export async function fetchServerCategories(stateManager: SourceStateManager, re
     return categories
 }
 
-// Set Categories
 export async function setServerCategories(stateManager: SourceStateManager, categories: Record<string, tachiCategory>) {
     await stateManager.store(SERVER_CATEGORIES_KEY, categories)
 }
 
-// Get Categories
 export async function getServerCategories(stateManager: SourceStateManager) {
     return (await stateManager.retrieve(SERVER_CATEGORIES_KEY) as Record<string, tachiCategory> | undefined) ?? DEFAULT_SERVER_CATEGORIES
 }
 
-// Set Selected Categories
 export async function setSelectedCategories(stateManager: SourceStateManager, selectedCategories: string[]) {
     await stateManager.store(SELECTED_CATEGORIES_KEY, selectedCategories)
 }
 
-// Get Selected Categories
 export async function getSelectedCategories(stateManager: SourceStateManager) {
     return (await stateManager.retrieve(SELECTED_CATEGORIES_KEY) as string[] | undefined) ?? DEFAULT_SELECTED_CATEGORIES;
 }
 
 export function getCategoriesIds(categories: Record<string, tachiCategory>) {
     let categoryIds: string[] = [];
-
     Object.values(categories).forEach(category => {
         categoryIds.push(JSON.stringify(category.id))
     })
+
     return categoryIds
 }
-export function getCategoryFromId(categories: Record<string, tachiCategory>, id: string) : tachiCategory{
-    const default_category : tachiCategory = {
-        id: 0,
-        order: 0,
-        name: "Default",
-        default: true,
-        size: 0,
-        includeInUpdate: "EXCLUDE",
-        meta: {
-            "additionalProp1": "string",
-            "additionalProp2": "string",
-            "additionalProp3": "string"
-        }
-    }
-    return categories[id] ?? default_category
+
+export function getCategoryFromId(categories: Record<string, tachiCategory>, id: string): tachiCategory {
+    return categories[id] ?? DEFAULT_SERVER_CATEGORY
 }
 
 export function getCategoryNameFromId(categories: Record<string, tachiCategory>, id: string) {
     let categoryName = ""
-
     Object.values(categories).forEach(category => {
         if (JSON.stringify(category.id) == id) {
             categoryName = category.name
@@ -380,12 +357,11 @@ export function getCategoryNameFromId(categories: Record<string, tachiCategory>,
 // ! Categories End
 
 // ! Sources Start
-// Fetch Sources -- get with a fetch
+// Fetch Sources from server
 export async function fetchServerSources(stateManager: SourceStateManager, requestManager: RequestManager) {
     let sources: Record<string, tachiSources> = {};
 
     const fetchedSources = await makeRequest(stateManager, requestManager, "source/list")
-
     fetchedSources.forEach((source: tachiSources) => {
         sources[source.id] = source
     });
@@ -393,29 +369,24 @@ export async function fetchServerSources(stateManager: SourceStateManager, reque
     return sources
 }
 
-// Set Sources
 export async function setServerSources(stateManager: SourceStateManager, sources: Record<string, tachiSources>) {
     await stateManager.store(SERVER_SOURCES_KEY, sources);
 }
 
-// Get Sources
 export async function getServerSources(stateManager: SourceStateManager) {
     return (await stateManager.retrieve(SERVER_SOURCES_KEY) as Record<string, tachiSources> | undefined) ?? DEFAULT_SERVER_SOURCES
 }
 
-// Set Selected Sources
 export async function setSelectedSources(stateManager: SourceStateManager, selectedSources: string[]) {
     await stateManager.store(SELECTED_SOURCES_KEY, selectedSources)
 }
 
-// Get Selected Sources
 export async function getSelectedSources(stateManager: SourceStateManager) {
     return (await stateManager.retrieve(SELECTED_SOURCES_KEY) as string[] | undefined) ?? DEFAULT_SELECTED_SOURCES
 }
 
 export function getSourcesIds(sources: Record<string, tachiSources>) {
     let sourceIds: string[] = [];
-
     Object.values(sources).forEach(source => {
         sourceIds.push(source.id)
     })
@@ -423,24 +394,12 @@ export function getSourcesIds(sources: Record<string, tachiSources>) {
     return sourceIds
 }
 
-export function getSourceFromId(sources: Record<string, tachiSources>, id: string) : tachiSources{
-    const default_category : tachiSources = {
-        id: "0",
-        name: "Local source",
-        lang: "localsourcelang",
-        iconUrl: "/api/v1/extension/icon/localSource",
-        supportsLatest: true,
-        isConfigurable: false,
-        isNsfw: false,
-        displayName: "Local source"
-    }
-
-    return sources[id] ?? default_category
+export function getSourceFromId(sources: Record<string, tachiSources>, id: string): tachiSources {
+    return sources[id] ?? DEFAULT_SERVER_SOURCE
 }
 
 export function getSourceNameFromId(sources: Record<string, tachiSources>, id: string) {
     let sourceName = ""
-
     Object.values(sources).forEach(source => {
         if (source.id === id) {
             sourceName = source.displayName
@@ -449,34 +408,9 @@ export function getSourceNameFromId(sources: Record<string, tachiSources>, id: s
 
     return sourceName
 }
-
 // ! Sources End
 
 // ! Homepage Settings Start
-
-export const DEFAULT_MANGA_PER_ROW = 10;
-export const DEFAULT_UPDATED_ROW_STATE = true
-export const DEFAULT_CATEGORY_ROW_STATE = true
-export const DEFAULT_SOURCE_ROW_STATE = true
-export const DEFAULT_UPDATED_ROW_STYLE = ["singleRowNormal"]
-export const DEFAULT_CATEGORY_ROW_STYLE = ["singleRowNormal"]
-export const DEFAULT_SOURCE_ROW_STYLE = ["singleRowNormal"]
-
-export const MANGA_PER_ROW_KEY = "mangaPerRow"
-export const UPDATED_ROW_STATE_KEY = "updatedRowState"
-export const CATEGORY_ROW_STATE_KEY = "categoryRowState"
-export const SOURCE_ROW_STATE_KEY = "sourceRowState"
-export const UPDATED_ROW_STYLE_KEY = "updatedRowStyle"
-export const CATEGORY_ROW_STYLE_KEY = "categoryRowStyle"
-export const SOURCE_ROW_STYLE_KEY = "sourceRowStyle"
-
-export const rowStyles : {[key: string]: HomeSectionType}= {
-    "singleRowNormal": HomeSectionType.singleRowNormal,
-    "singleRowLarge": HomeSectionType.singleRowLarge,
-    "featured": HomeSectionType.featured,
-    "doubleRow": HomeSectionType.doubleRow
-}
-
 export function styleResolver(style: string): string {
     switch (style) {
         case "singleRowNormal":

--- a/src/TachiDesk/Common.ts
+++ b/src/TachiDesk/Common.ts
@@ -181,7 +181,6 @@ export class TachiSourcesClass {
     }
 
     getAllSources = () => {
-        console.log(this.allSources ?? this.DEFAULT_SOURCES)
         return this.allSources ?? this.DEFAULT_SOURCES
     }
 

--- a/src/TachiDesk/Common.ts
+++ b/src/TachiDesk/Common.ts
@@ -53,11 +53,11 @@ export class TachiAPIClass {
             data,
             headers
         });
-
+        console.log(JSON.stringify([request.url,request.headers,request.param ?? "", request.method, request.data, request.headers]))
         let response;
         let responseStatus;
         let responseData;
-
+        
         try {
             response = await requestManager.schedule(request, 0);
         }
@@ -186,6 +186,7 @@ export class TachiSourcesClass {
     }
 
     getAllSources = () => {
+        console.log(this.allSources ?? this.DEFAULT_SOURCES)
         return this.allSources ?? this.DEFAULT_SOURCES
     }
 

--- a/src/TachiDesk/Common.ts
+++ b/src/TachiDesk/Common.ts
@@ -1,4 +1,5 @@
 import {
+    HomeSectionType,
     RequestManager,
     SourceStateManager
 } from '@paperback/types'
@@ -14,201 +15,536 @@ export function serverUnavailableMangaTiles() {
     ]
 }
 
-export class TachiAPIClass {
-    serverAddress = "http://127.0.0.1:4567";
-    baseEndpoint = "/api/v1";
-    serverKey = "server_address";
+// Defaults
+export const DEFAULT_SERVER_URL = "http://127.0.0.1:4567/";
+export const DEFAULT_API_ENDPOINT = "api/v1/";
+export const DEFAULT_SERVER_API = DEFAULT_SERVER_URL + DEFAULT_API_ENDPOINT;
+export const DEFAULT_AUTH_STATE = false;
+export const DEFAULT_AUTH_STRING = "";
+export const DEFAULT_USERNAME = "";
+export const DEFAULT_PASSWORD = "";
 
-    // Initialize function by getting server address and returns itself
-    init = async (stateManager: SourceStateManager) => {
-        this.serverAddress = await this.getServerAddress(stateManager);
-        return this;
-    }
-
-    // Gets server address, and removes the slash from the end of the server (if there)
-    getServerAddress = async (stateManager: SourceStateManager) => {
-        let serverAddress = await stateManager.retrieve(this.serverKey) ?? this.serverAddress;
-        serverAddress = serverAddress.slice(-1) === '/' ? serverAddress.slice(0, -1) : serverAddress
-        return serverAddress
-    }
-
-    // Sets server address with statemanager and saves the values
-    setServerAddress = async (stateManager: SourceStateManager, serverAddress: any) => {
-        serverAddress = serverAddress.slice(-1) === '/' ? serverAddress.slice(0, -1) : serverAddress
-
-        await stateManager.store(this.serverKey, serverAddress);
-        this.serverAddress = serverAddress;
-    }
-
-    getBaseURL = () => {
-        return this.serverAddress + this.baseEndpoint;
-    }
-
-    // Packages all the request processing.
-    // Creates request, checks if request reaches, if the request was good, and if response is JSON.
-    makeRequest = async (requestManager: RequestManager, apiEndpoint: string, method = "GET", data = {}, headers = {}) => {
-        const request = App.createRequest({
-            url: this.getBaseURL() + apiEndpoint,
-            method,
-            data,
-            headers
-        });
-
-        let response;
-        let responseStatus;
-        let responseData;
-
-        try {
-            response = await requestManager.schedule(request, 0);
+export const DEFAULT_SERVER_CATEGORIES: Record<string, tachiCategory> = {
+    "0": {
+        id: 0,
+        order: 0,
+        name: "Default",
+        default: true,
+        size: 0,
+        includeInUpdate: "EXCLUDE",
+        meta: {
+            "additionalProp1": "string",
+            "additionalProp2": "string",
+            "additionalProp3": "string"
         }
-        catch (error: any) {
-            return new Error(this.getBaseURL() + apiEndpoint)
-        }
-
-        try {
-            responseStatus = response?.status
-        }
-        catch (error: any) {
-            return Error("Couldn't connect to server.")
-        }
-
-        if (responseStatus != 200) {
-            return Error("Your query is invalid.")
-        }
-
-        try {
-            responseData = JSON.parse(response.data ?? "")
-        }
-        catch (error: any) {
-            return Error(apiEndpoint)
-        }
-
-        return responseData
     }
+};
+export const DEFAULT_SELECTED_CATEGORIES = ["0"];
 
-    // Test request (for test server settings)
-    testRequest = async (requestManager: RequestManager) => {
-        return await this.makeRequest(requestManager, "/settings/about/")
-    }
-
-}
-
-export class TachiCategoriesClass {
-    // Categories are sent in order, so there's no point in me saving them
-    DEFAULT_CATEGORIES: any = {
-        "0": "Default"
-    }
-    DEFAULT_API_ENDPOINT = "/category/"
-
-    allCategories = this.DEFAULT_CATEGORIES;
-    selectedCategories = Object.keys(this.allCategories);
-
-    selectedCategoryKey = "selected_category"
-
-    // Initialize by getting AllCategories and selectedCategories
-    init = async (stateManager: SourceStateManager, requestManager: RequestManager, tachiAPI: TachiAPIClass) => {
-        this.allCategories = this.DEFAULT_CATEGORIES;
-        this.selectedCategories = await stateManager.retrieve(this.selectedCategoryKey) ?? this.selectedCategories;
-        const requestedCategories = await tachiAPI.makeRequest(requestManager, this.DEFAULT_API_ENDPOINT);
-
-        if (requestedCategories instanceof Error) {
-            return requestedCategories;
-        }
-
-        for (const category of requestedCategories) {
-            this.allCategories[category.id] = category.name;
-        }
-
-        return this;
-    };
-
-    // Returns allCategories, could be better for stability to run another stateManager retreive and use allcategories as default value
-    getAllCategories = () => {
-        return this.allCategories
-    };
-
-    getSelectedCategories = async (stateManager: SourceStateManager) => {
-        return await stateManager.retrieve(this.selectedCategoryKey) ?? this.selectedCategories;
-    };
-
-    setSelectedCategories = async (stateManager: SourceStateManager, categories: any) => {
-        await stateManager.store(this.selectedCategoryKey, categories)
-        this.selectedCategories = categories
-    };
-
-    // allCategories == {id: name}, thus allcategories[id] == name.
-    // Used by label resolver
-    getSelectedCategoryFromId = (categoryId: string) => {
-        return this.allCategories[categoryId] ?? ""
-    };
-}
-
-export class TachiSourcesClass {
-    DEFAULT_SOURCES = {
-        "0": {
-            "name": "Local source",
-            "lang": "localsourcelang",
-            "iconUrl": "/api/v1/extension/icon/localSource",
-            "supportsLatest": true,
-            "isConfigurable": false,
-            "isNsfw": false,
-            "displayName": "Local source"
-        }
-    };
-
-
-    allSources: any = this.DEFAULT_SOURCES;
-    selectedSources = Object.keys(this.allSources);
-
-    DEFAULT_API_ENDPOINT = "/source/list";
-
-    allSourcesKey = "all_sources"
-    selectedSourceKey = "selected_sources"
-
-    // Initializes by getting selected sources and set all sources
-    init = async (stateManager: SourceStateManager, requestManager: RequestManager, tachiAPI: TachiAPIClass) => {
-        this.selectedSources = await stateManager.retrieve(this.selectedSourceKey) ?? this.selectedSources;
-        const requestedSources = await tachiAPI.makeRequest(requestManager, this.DEFAULT_API_ENDPOINT)
-
-        if (requestedSources instanceof Error) {
-            return requestedSources
-        }
-
-        this.setAllSources(stateManager, requestedSources)
-        return this
-    }
-
-    getAllSources = () => {
-        return this.allSources ?? this.DEFAULT_SOURCES
-    }
-
-    setAllSources = async (stateManager: SourceStateManager, allSources: any) => {
-        for (const source of allSources) {
-            this.allSources[source.id] = {
-                "name": source.name,
-                "lang": source.lang,
-                "iconUrl": source.iconUrl,
-                "supportsLatest": source.supportsLatest,
-                "isConfigurable": source.isConfigurable,
-                "isNsfw": source.isNsfw,
-                "displayName": source.displayName
-            }
-        }
-
-        await stateManager.store(this.allSourcesKey, this.allSources)
-    }
-
-    getSelectedSources = async (stateManager: SourceStateManager) => {
-        return await stateManager.retrieve(this.selectedSourceKey) ?? this.selectedSources;
-    }
-
-    setSelectedSources = async (stateManager: SourceStateManager, sources: any) => {
-        await stateManager.store(this.selectedSourceKey, sources)
-        this.selectedSources = sources;
-    }
-
-    getSourceNameFromId = (sourceId: string) => {
-        return this.allSources[sourceId]["displayName"] ?? "";
+export const DEFAULT_SERVER_SOURCES: Record<string, tachiSources> = {
+    "0": {
+        id: "0",
+        name: "Local source",
+        lang: "localsourcelang",
+        iconUrl: "/api/v1/extension/icon/localSource",
+        supportsLatest: true,
+        isConfigurable: false,
+        isNsfw: false,
+        displayName: "Local source"
     }
 }
+export const DEFAULT_SELECTED_SOURCES = ["0"]
 
+// StateManager Keys
+export const SERVER_URL_KEY = "serverURL";
+export const SERVER_API_KEY = "serverAPI";
+export const AUTH_STATE_KEY = "AuthState";
+export const AUTH_STRING_KEY = "AuthString";
+export const USERNAME_KEY = "serverUsername";
+export const PASSWORD_KEY = "serverPassword";
+
+export const SERVER_CATEGORIES_KEY = "serverCategories";
+export const SELECTED_CATEGORIES_KEY = "selectedCategories";
+
+export const SERVER_SOURCES_KEY = "serverSources";
+export const SELECTED_SOURCES_KEY = "selectedSources";
+
+// ! Query Interfaces Start
+// interface categories
+export interface tachiCategory {
+    id: number,
+    order: number,
+    name: string,
+    default: boolean,
+    size: number,
+    includeInUpdate: string,
+    meta: any
+}
+
+export interface tachiSources {
+    "id": string,
+    "name": string,
+    "lang": string,
+    "iconUrl": string,
+    "supportsLatest": boolean,
+    "isConfigurable": boolean,
+    "isNsfw": boolean,
+    "displayName": string
+}
+
+export interface tachiManga {
+    "id": number,
+    "sourceId": string,
+    "url": string,
+    "title": string,
+    "thumbnailUrl": string,
+    "thumbnailUrlLastFetched": number,
+    "initialized": boolean,
+    "artist": string,
+    "author": string,
+    "description": string,
+    "genre": string[],
+    "status": string,
+    "inLibrary": boolean,
+    "inLibraryAt": number,
+    "source": tachiSources,
+    "meta": any,
+    "realUrl": string,
+    "lastFetchedAt": number,
+    "chaptersLastFetchedAt": number,
+    "updateStrategy": string,
+    "freshData": boolean,
+    "unreadCount": number,
+    "downloadCount": number,
+    "chapterCount": number,
+    "lastReadAt": number,
+    "lastChapterRead": tachiChapter,
+    "age": number,
+    "chaptersAge": number
+}
+
+export interface tachiChapter {
+    "id": number,
+    "url": string,
+    "name": string,
+    "uploadDate": number,
+    "chapterNumber": number,
+    "scanlator": string,
+    "mangaId": number,
+    "read": boolean,
+    "bookmarked": boolean,
+    "lastPageRead": number,
+    "lastReadAt": number,
+    "index": number,
+    "fetchedAt": number,
+    "realUrl": string,
+    "downloaded": boolean,
+    "pageCount": number,
+    "chapterCount": number,
+    "meta": any
+}
+
+// ! Query Interfaces End
+
+// ! Reset Settings Begin
+export async function resetSettings(stateManager: SourceStateManager) {
+    await stateManager.store(SERVER_URL_KEY, DEFAULT_SERVER_URL)
+    await stateManager.store(SERVER_API_KEY, DEFAULT_SERVER_API)
+    await stateManager.store(AUTH_STATE_KEY, DEFAULT_AUTH_STATE)
+    await stateManager.keychain.store(AUTH_STRING_KEY, DEFAULT_AUTH_STRING)
+    await stateManager.store(USERNAME_KEY, DEFAULT_USERNAME)
+    await stateManager.keychain.store(PASSWORD_KEY, DEFAULT_PASSWORD)
+    await stateManager.store(SERVER_CATEGORIES_KEY, DEFAULT_SERVER_CATEGORIES)
+    await stateManager.store(SELECTED_CATEGORIES_KEY, DEFAULT_SELECTED_CATEGORIES)
+    await stateManager.store(SERVER_SOURCES_KEY, DEFAULT_SERVER_SOURCES)
+    await stateManager.store(SELECTED_SOURCES_KEY, DEFAULT_SELECTED_SOURCES)
+    await stateManager.store(MANGA_PER_ROW_KEY,DEFAULT_MANGA_PER_ROW)
+    await stateManager.store(UPDATED_ROW_STATE_KEY,DEFAULT_UPDATED_ROW_STATE)
+    await stateManager.store(CATEGORY_ROW_STATE_KEY,DEFAULT_CATEGORY_ROW_STATE)
+    await stateManager.store(SOURCE_ROW_STATE_KEY,DEFAULT_SOURCE_ROW_STATE)
+    await stateManager.store(UPDATED_ROW_STYLE_KEY,DEFAULT_UPDATED_ROW_STYLE)
+    await stateManager.store(CATEGORY_ROW_STYLE_KEY,DEFAULT_CATEGORY_ROW_STYLE)
+    await stateManager.store(SOURCE_ROW_STYLE_KEY,DEFAULT_SOURCE_ROW_STYLE)
+}
+// ! Reset Settings End
+
+// ! Server URL start
+
+// Clean server URL
+export function cleanServerURL(url: String) {
+    // If last character isn't a /, then add it to the url
+    return url.slice(-1) === '/' ? url : url + "/"
+}
+
+// Set server URL
+export async function setServerURL(stateManager: SourceStateManager, url: String) {
+    url = url == "" ? DEFAULT_SERVER_URL : url
+    await stateManager.store(SERVER_URL_KEY, cleanServerURL(url))
+    await stateManager.store(SERVER_API_KEY, cleanServerURL(url) + DEFAULT_API_ENDPOINT)
+}
+
+// get server URL
+export async function getServerURL(stateManager: SourceStateManager) {
+    return (await stateManager.retrieve(SERVER_URL_KEY) as string | undefined) ?? DEFAULT_SERVER_URL
+}
+
+// Get Server API url (i.e. http://127.0.0.1/api/v1/)
+export async function getServerAPI(stateManager: SourceStateManager) {
+    return (await stateManager.retrieve(SERVER_API_KEY) as string | undefined) ?? DEFAULT_SERVER_API
+}
+
+// !Server URL End
+
+// ! Authentication start
+
+// Set AuthState
+export async function setAuthState(stateManager: SourceStateManager, state: boolean) {
+    await stateManager.store(AUTH_STATE_KEY, state)
+}
+
+// Get AuthState
+export async function getAuthState(stateManager: SourceStateManager) {
+    return (await stateManager.retrieve(AUTH_STATE_KEY) as boolean | undefined) ?? DEFAULT_AUTH_STATE
+}
+
+// Set Auth String
+export async function setAuthString(stateManager: SourceStateManager) {
+    let username = await getUsername(stateManager);
+    let password = await getPassword(stateManager);
+
+    let authString = 'Basic ' + Buffer.from(username + ':' + password, 'binary').toString('base64');
+
+    await stateManager.keychain.store(AUTH_STRING_KEY, authString);
+}
+
+// Get Auth String
+export async function getAuthString(stateManager: SourceStateManager) {
+    return (await stateManager.keychain.retrieve(AUTH_STRING_KEY) as string | undefined) ?? DEFAULT_AUTH_STRING;
+}
+
+// Set Username
+export async function setUsername(stateManager: SourceStateManager, username: string) {
+    await stateManager.store(USERNAME_KEY, username);
+    await setAuthString(stateManager)
+}
+
+// Get Username
+export async function getUsername(stateManager: SourceStateManager) {
+    return (await stateManager.retrieve(USERNAME_KEY) as string | undefined) ?? DEFAULT_USERNAME;
+}
+
+// Set Password
+export async function setPassword(stateManager: SourceStateManager, password: string) {
+    await stateManager.keychain.store(PASSWORD_KEY, password);
+    await setAuthString(stateManager);
+}
+
+// Get Password
+export async function getPassword(stateManager: SourceStateManager) {
+    return (await stateManager.keychain.retrieve(PASSWORD_KEY) as string | undefined) ?? DEFAULT_PASSWORD;
+}
+
+// ! Authentication End
+
+// ! Requests
+
+// Make Request
+export async function makeRequest(stateManager: SourceStateManager, requestManager: RequestManager, apiEndpoint: string, method = "GET", data: Record<string, string> = {}, headers: Record<string, string> = {}) {
+    const serverAPI = await getServerAPI(stateManager)
+    const authEnabled = await getAuthState(stateManager);
+
+    if (authEnabled) {
+        headers['Authorization'] = await getAuthString(stateManager);
+    }
+    const request = App.createRequest({
+        url: serverAPI + apiEndpoint,
+        method,
+        data,
+        headers
+    })
+
+    let response;
+    let responseStatus;
+    let responseData;
+
+    try {
+        response = await requestManager.schedule(request, 0);
+    }
+    catch (error: any) {
+        return new Error(serverAPI + apiEndpoint)
+    }
+
+    try {
+        responseStatus = response?.status
+    }
+    catch (error: any) {
+        return Error("Couldn't connect to server.")
+    }
+    if (responseStatus == 401) {
+        return Error("Unauthorized" + " " + JSON.stringify(await getAuthString(stateManager)))
+    }
+
+    if (responseStatus != 200) {
+        return Error("Your query is invalid. " + JSON.stringify(response?.status))
+    }
+
+    try {
+        responseData = JSON.parse(response.data ?? "")
+    }
+    catch (error: any) {
+        return Error(apiEndpoint)
+    }
+
+    return responseData
+}
+
+// Test Request
+export async function testRequest(stateManager: SourceStateManager, requestManager: RequestManager) {
+    return await makeRequest(stateManager, requestManager, "settings/about/")
+}
+
+// ! Requests End
+
+
+
+// ! Categories Start
+// Fetch Categories -- get with a fetch
+export async function fetchServerCategories(stateManager: SourceStateManager, requestManager: RequestManager) {
+    let categories: Record<string, tachiCategory> = {};
+
+    const fetchedCategories = await makeRequest(stateManager, requestManager, "category/");
+
+    fetchedCategories.forEach((category: tachiCategory) => {
+        categories[JSON.stringify(category.id)] = category
+    });
+
+    return categories
+}
+
+// Set Categories
+export async function setServerCategories(stateManager: SourceStateManager, categories: Record<string, tachiCategory>) {
+    await stateManager.store(SERVER_CATEGORIES_KEY, categories)
+}
+
+// Get Categories
+export async function getServerCategories(stateManager: SourceStateManager) {
+    return (await stateManager.retrieve(SERVER_CATEGORIES_KEY) as Record<string, tachiCategory> | undefined) ?? DEFAULT_SERVER_CATEGORIES
+}
+
+// Set Selected Categories
+export async function setSelectedCategories(stateManager: SourceStateManager, selectedCategories: string[]) {
+    await stateManager.store(SELECTED_CATEGORIES_KEY, selectedCategories)
+}
+
+// Get Selected Categories
+export async function getSelectedCategories(stateManager: SourceStateManager) {
+    return (await stateManager.retrieve(SELECTED_CATEGORIES_KEY) as string[] | undefined) ?? DEFAULT_SELECTED_CATEGORIES;
+}
+
+export function getCategoriesIds(categories: Record<string, tachiCategory>) {
+    let categoryIds: string[] = [];
+
+    Object.values(categories).forEach(category => {
+        categoryIds.push(JSON.stringify(category.id))
+    })
+    return categoryIds
+}
+export function getCategoryFromId(categories: Record<string, tachiCategory>, id: string) : tachiCategory{
+    const default_category : tachiCategory = {
+        id: 0,
+        order: 0,
+        name: "Default",
+        default: true,
+        size: 0,
+        includeInUpdate: "EXCLUDE",
+        meta: {
+            "additionalProp1": "string",
+            "additionalProp2": "string",
+            "additionalProp3": "string"
+        }
+    }
+    return categories[id] ?? default_category
+}
+
+export function getCategoryNameFromId(categories: Record<string, tachiCategory>, id: string) {
+    let categoryName = ""
+
+    Object.values(categories).forEach(category => {
+        if (JSON.stringify(category.id) == id) {
+            categoryName = category.name
+        }
+    })
+
+    return categoryName
+}
+// ! Categories End
+
+// ! Sources Start
+// Fetch Sources -- get with a fetch
+export async function fetchServerSources(stateManager: SourceStateManager, requestManager: RequestManager) {
+    let sources: Record<string, tachiSources> = {};
+
+    const fetchedSources = await makeRequest(stateManager, requestManager, "source/list")
+
+    fetchedSources.forEach((source: tachiSources) => {
+        sources[source.id] = source
+    });
+
+    return sources
+}
+
+// Set Sources
+export async function setServerSources(stateManager: SourceStateManager, sources: Record<string, tachiSources>) {
+    await stateManager.store(SERVER_SOURCES_KEY, sources);
+}
+
+// Get Sources
+export async function getServerSources(stateManager: SourceStateManager) {
+    return (await stateManager.retrieve(SERVER_SOURCES_KEY) as Record<string, tachiSources> | undefined) ?? DEFAULT_SERVER_SOURCES
+}
+
+// Set Selected Sources
+export async function setSelectedSources(stateManager: SourceStateManager, selectedSources: string[]) {
+    await stateManager.store(SELECTED_SOURCES_KEY, selectedSources)
+}
+
+// Get Selected Sources
+export async function getSelectedSources(stateManager: SourceStateManager) {
+    return (await stateManager.retrieve(SELECTED_SOURCES_KEY) as string[] | undefined) ?? DEFAULT_SELECTED_SOURCES
+}
+
+export function getSourcesIds(sources: Record<string, tachiSources>) {
+    let sourceIds: string[] = [];
+
+    Object.values(sources).forEach(source => {
+        sourceIds.push(source.id)
+    })
+
+    return sourceIds
+}
+
+export function getSourceFromId(sources: Record<string, tachiSources>, id: string) : tachiSources{
+    const default_category : tachiSources = {
+        id: "0",
+        name: "Local source",
+        lang: "localsourcelang",
+        iconUrl: "/api/v1/extension/icon/localSource",
+        supportsLatest: true,
+        isConfigurable: false,
+        isNsfw: false,
+        displayName: "Local source"
+    }
+
+    return sources[id] ?? default_category
+}
+
+export function getSourceNameFromId(sources: Record<string, tachiSources>, id: string) {
+    let sourceName = ""
+
+    Object.values(sources).forEach(source => {
+        if (source.id === id) {
+            sourceName = source.displayName
+        }
+    })
+
+    return sourceName
+}
+
+// ! Sources End
+
+// ! Homepage Settings Start
+
+export const DEFAULT_MANGA_PER_ROW = 10;
+export const DEFAULT_UPDATED_ROW_STATE = true
+export const DEFAULT_CATEGORY_ROW_STATE = true
+export const DEFAULT_SOURCE_ROW_STATE = true
+export const DEFAULT_UPDATED_ROW_STYLE = ["singleRowNormal"]
+export const DEFAULT_CATEGORY_ROW_STYLE = ["singleRowNormal"]
+export const DEFAULT_SOURCE_ROW_STYLE = ["singleRowNormal"]
+
+export const MANGA_PER_ROW_KEY = "mangaPerRow"
+export const UPDATED_ROW_STATE_KEY = "updatedRowState"
+export const CATEGORY_ROW_STATE_KEY = "categoryRowState"
+export const SOURCE_ROW_STATE_KEY = "sourceRowState"
+export const UPDATED_ROW_STYLE_KEY = "updatedRowStyle"
+export const CATEGORY_ROW_STYLE_KEY = "categoryRowStyle"
+export const SOURCE_ROW_STYLE_KEY = "sourceRowStyle"
+
+export const rowStyles : {[key: string]: HomeSectionType}= {
+    "singleRowNormal": HomeSectionType.singleRowNormal,
+    "singleRowLarge": HomeSectionType.singleRowLarge,
+    "featured": HomeSectionType.featured,
+    "doubleRow": HomeSectionType.doubleRow
+}
+
+export function styleResolver(style: string): string {
+    switch (style) {
+        case "singleRowNormal":
+            return "Normal Single Row"
+        case "singleRowLarge":
+            return "Large Single Row"
+        case "featured":
+            return "Featured"
+        case "doubleRow":
+            return "Double Row"
+        default:
+            return ""
+    }
+}
+
+export async function setMangaPerRow(stateManager: SourceStateManager, rowNumber: number) {
+    await stateManager.store(MANGA_PER_ROW_KEY, rowNumber)
+}
+
+export async function getMangaPerRow(stateManager: SourceStateManager) {
+    return (await stateManager.retrieve(MANGA_PER_ROW_KEY) as number | undefined) ?? DEFAULT_MANGA_PER_ROW;
+}
+
+export async function setUpdatedRowState(stateManager: SourceStateManager, state: boolean) {
+    await stateManager.store(UPDATED_ROW_STATE_KEY, state)
+}
+
+export async function getUpdatedRowState(stateManager: SourceStateManager) {
+    return (await stateManager.retrieve(UPDATED_ROW_STATE_KEY) as boolean | undefined) ?? DEFAULT_UPDATED_ROW_STATE;
+}
+
+export async function setCategoryRowState(stateManager: SourceStateManager, state: boolean) {
+    await stateManager.store(CATEGORY_ROW_STATE_KEY, state)
+}
+
+export async function getCategoryRowState(stateManager: SourceStateManager) {
+    return (await stateManager.retrieve(CATEGORY_ROW_STATE_KEY) as boolean | undefined) ?? DEFAULT_CATEGORY_ROW_STATE;
+}
+
+export async function setSourceRowState(stateManager: SourceStateManager, state: boolean) {
+    await stateManager.store(SOURCE_ROW_STATE_KEY, state)
+}
+
+export async function getSourceRowState(stateManager: SourceStateManager) {
+    return (await stateManager.retrieve(SOURCE_ROW_STATE_KEY) as boolean | undefined) ?? DEFAULT_SOURCE_ROW_STATE;
+}
+
+export async function setUpdatedRowStyle(stateManager: SourceStateManager, style: string[]) {
+    await stateManager.store(UPDATED_ROW_STYLE_KEY, style)
+}
+
+export async function getUpdatedRowStyle(stateManager: SourceStateManager) {
+    return (await stateManager.retrieve(UPDATED_ROW_STYLE_KEY) as string[] | undefined) ?? DEFAULT_UPDATED_ROW_STYLE;
+}
+
+export async function setCategoryRowStyle(stateManager: SourceStateManager, style: string[]) {
+    await stateManager.store(CATEGORY_ROW_STYLE_KEY, style)
+}
+
+export async function getCategoryRowStyle(stateManager: SourceStateManager) {
+    return (await stateManager.retrieve(CATEGORY_ROW_STYLE_KEY) as string[] | undefined) ?? DEFAULT_CATEGORY_ROW_STYLE;
+}
+
+export async function setSourceRowStyle(stateManager: SourceStateManager, style: string) {
+    await stateManager.store(SOURCE_ROW_STYLE_KEY, style)
+}
+
+export async function getSourceRowStyle(stateManager: SourceStateManager) {
+    return (await stateManager.retrieve(SOURCE_ROW_STYLE_KEY) as string[] | undefined) ?? DEFAULT_SOURCE_ROW_STYLE;
+}
+// ! Homepage Settings End

--- a/src/TachiDesk/Common.ts
+++ b/src/TachiDesk/Common.ts
@@ -293,11 +293,7 @@ export async function getPassword(stateManager: SourceStateManager) {
 // ! Requests
 export async function makeRequest(stateManager: SourceStateManager, requestManager: RequestManager, apiEndpoint: string, method = "GET", data: Record<string, string> = {}, headers: Record<string, string> = {}) {
     const serverAPI = await getServerAPI(stateManager)
-    const authEnabled = await getAuthState(stateManager);
 
-    if (authEnabled) {
-        headers['Authorization'] = await getAuthString(stateManager);
-    }
     const request = App.createRequest({
         url: serverAPI + apiEndpoint,
         method,

--- a/src/TachiDesk/Common.ts
+++ b/src/TachiDesk/Common.ts
@@ -28,6 +28,8 @@ export const SELECTED_CATEGORIES_KEY = "selectedCategories";
 export const SERVER_SOURCES_KEY = "serverSources";
 export const SELECTED_SOURCES_KEY = "selectedSources";
 
+export const SELECTED_LANGUAGES_KEY = "selectedLanguages"
+
 export const MANGA_PER_ROW_KEY = "mangaPerRow"
 export const UPDATED_ROW_STATE_KEY = "updatedRowState"
 export const CATEGORY_ROW_STATE_KEY = "categoryRowState"
@@ -76,6 +78,8 @@ export const DEFAULT_SERVER_SOURCES: Record<string, tachiSources> = {
 }
 export const DEFAULT_SELECTED_SOURCES = ["0"]
 
+export const DEFAULT_SELECTED_LANGUAGES = ["localsourcelang", "en"]
+
 export const DEFAULT_MANGA_PER_ROW = 10;
 export const DEFAULT_UPDATED_ROW_STATE = true
 export const DEFAULT_CATEGORY_ROW_STATE = true
@@ -83,7 +87,50 @@ export const DEFAULT_SOURCE_ROW_STATE = true
 export const DEFAULT_UPDATED_ROW_STYLE = ["singleRowNormal"]
 export const DEFAULT_CATEGORY_ROW_STYLE = ["singleRowNormal"]
 export const DEFAULT_SOURCE_ROW_STYLE = ["singleRowNormal"]
+
 export const rowStyles = ["singleRowNormal", "singleRowLarge", "featured", "doubleRow"]
+export const languages: Record<string, string> = {
+    'ar': 'اَلْعَرَبِيَّةُ', // Arabic
+    'bg': 'български', // Bulgarian
+    'bn': 'বাংলা', // Bengali
+    'ca': 'Català', // Catalan
+    'cs': 'Čeština', // Czech
+    'da': 'Dansk', // Danish
+    'de': 'Deutsch', // German
+    'en': 'English', // English
+    'es': 'Español', // Spanish
+    'es-419': 'Español (Latinoamérica)', // Spanish (Latin American)
+    'fa': 'فارسی', // Farsi
+    'fi': 'Suomi', // Finnish
+    'fr': 'Français', // French
+    'he': 'עִבְרִית', // Hebrew
+    'hi': 'हिन्दी', // Hindi
+    'hu': 'Magyar', // Hungarian
+    'id': 'Indonesia', // Indonesian
+    'it': 'Italiano', // Italian
+    'ja': '日本語', // Japanese
+    'ko': '한국어', // Korean
+    'lt': 'Lietuvių', // Lithuanian
+    'mn': 'монгол', // Mongolian
+    'ms': 'Melayu', // Malay
+    'my': 'မြန်မာဘာသာ', // Burmese
+    'nl': 'Nederlands', // Dutch
+    'no': 'Norsk', // Norwegian
+    'pl': 'Polski', // Polish
+    'pt': 'Português', // Portuguese
+    'pt-BR': 'Português (Brasil)', // Portuguese (Brazilian)
+    'ro': 'Română', // Romanian
+    'ru': 'Pусский', // Russian
+    'sr': 'Cрпски', // Serbian
+    'sv': 'Svenska', // Swedish
+    'th': 'ไทย', // Thai
+    'tl': 'Filipino', // Tagalog
+    'tr': 'Türkçe', // Turkish
+    'uk': 'Yкраї́нська', // Ukrainian
+    'vi': 'Tiếng Việt', // Vietnamese
+    'zh-Hans': '中文 (简化字)', // Chinese (Simplified)
+    'zh-Hant': '中文 (繁體字)', // Chinese (Traditional)
+}
 
 // ! Query Interfaces Start
 // interface categories
@@ -186,7 +233,7 @@ export async function resetSettings(stateManager: SourceStateManager) {
 
 // ! Server URL start
 
-export async function setServerURL(stateManager: SourceStateManager, url: String) {
+export async function setServerURL(stateManager: SourceStateManager, url: string) {
     url = url == "" ? DEFAULT_SERVER_URL : url
     url = url.slice(-1) === '/' ? url : url + "/" // Verified / at the end of URL
     await stateManager.store(SERVER_URL_KEY, url)
@@ -345,7 +392,7 @@ export function getCategoryFromId(categories: Record<string, tachiCategory>, id:
 }
 
 export function getCategoryNameFromId(categories: Record<string, tachiCategory>, id: string) {
-    let categoryName = ""
+    let categoryName = "OLD ENTRY OR ERROR"
     Object.values(categories).forEach(category => {
         if (JSON.stringify(category.id) == id) {
             categoryName = category.name
@@ -399,7 +446,7 @@ export function getSourceFromId(sources: Record<string, tachiSources>, id: strin
 }
 
 export function getSourceNameFromId(sources: Record<string, tachiSources>, id: string) {
-    let sourceName = ""
+    let sourceName = "OLD ENTRY OR ERROR"
     Object.values(sources).forEach(source => {
         if (source.id === id) {
             sourceName = source.displayName
@@ -482,3 +529,35 @@ export async function getSourceRowStyle(stateManager: SourceStateManager) {
     return (await stateManager.retrieve(SOURCE_ROW_STYLE_KEY) as string[] | undefined) ?? DEFAULT_SOURCE_ROW_STYLE;
 }
 // ! Homepage Settings End
+
+export async function getServerLanguages(stateManager : SourceStateManager){
+    const serverSources = await getServerSources(stateManager)
+    const serverLanguages = Object.values(serverSources).map((source) => source.lang)
+    const languages = getLanguageCodes()
+
+    let missedLanguages = []
+
+    for (const language of serverLanguages){
+        if(!(languages.includes(language))){
+            missedLanguages.push(language)
+        }
+    }
+
+    return missedLanguages
+}
+
+export function getLanguageCodes(){
+    return Object.keys(languages)
+}
+
+export function getLanguageName(languageCode : string) : string{
+    return languages[languageCode] ?? languageCode
+}
+
+export async function setSelectedLanguages(stateManager: SourceStateManager, languages: string[]){
+    await stateManager.store(SELECTED_LANGUAGES_KEY, languages)
+}
+
+export async function getSelectedLanguages(stateManager: SourceStateManager){
+    return (await stateManager.retrieve(SELECTED_LANGUAGES_KEY) as string[] | undefined) ?? DEFAULT_SELECTED_LANGUAGES
+}

--- a/src/TachiDesk/Settings.ts
+++ b/src/TachiDesk/Settings.ts
@@ -7,8 +7,6 @@ import {
 } from "@paperback/types"
 
 import {
-    DEFAULT_SELECTED_CATEGORIES,
-    DEFAULT_SELECTED_SOURCES,
     DEFAULT_SERVER_URL,
     fetchServerCategories,
     fetchServerSources,
@@ -52,7 +50,9 @@ import {
     testRequest
 } from "./Common"
 
+// 2 Sections -> 1 for server url, another for auth
 export const serverAddressSettings = (stateManager: SourceStateManager, requestManager: RequestManager): DUINavigationButton => {
+    // Label that shows test response
     let label = "Click on the button!"
 
     return App.createDUINavigationButton({
@@ -60,7 +60,6 @@ export const serverAddressSettings = (stateManager: SourceStateManager, requestM
         label: "Server Settings",
         form: App.createDUIForm({
             sections: async () => {
-
                 return [
                     App.createDUISection({
                         id: "urlSection",
@@ -97,13 +96,13 @@ export const serverAddressSettings = (stateManager: SourceStateManager, requestM
                     }),
                     App.createDUISection({
                         id: "authSettings",
-                        header: "Authentication",
+                        header: "Authorization",
                         isHidden: false,
                         rows: async () => [
                             // Auth Switch
                             App.createDUISwitch({
                                 id: "authStateSwitch",
-                                label: "Authorization Enabled",
+                                label: "Enabled",
                                 value: App.createDUIBinding({
                                     async get() {
                                         return await getAuthState(stateManager)
@@ -147,14 +146,14 @@ export const serverAddressSettings = (stateManager: SourceStateManager, requestM
     })
 }
 
+// Houses settings for Manga Per Row, and settings for each type of homepage section (recently updated, library category, and source )
+// for sections -> You can toggle them, change their style, change their content (which category/source)
 export const HomepageSettings = (stateManager:SourceStateManager, requestManager: RequestManager): DUINavigationButton => {
-    
     return App.createDUINavigationButton({
         id: "homepageSettings",
         label: "Homepage Settings",
         form: App.createDUIForm({
             sections: async () => {
-                
                 return [
                     App.createDUISection({
                         id: "mangaPerRowSection",
@@ -196,7 +195,7 @@ export const HomepageSettings = (stateManager:SourceStateManager, requestManager
                             App.createDUISelect({
                                 id: "updatedRowStyleSelect",
                                 label: "Style",
-                                options: Object.keys(rowStyles),
+                                options: rowStyles,
                                 allowsMultiselect: false,
                                 value: App.createDUIBinding({
                                     async get() {
@@ -232,7 +231,7 @@ export const HomepageSettings = (stateManager:SourceStateManager, requestManager
                             App.createDUISelect({
                                 id: "categoryRowStyleSelect",
                                 label: "Style",
-                                options: Object.keys(rowStyles),
+                                options: rowStyles,
                                 allowsMultiselect: false,
                                 value: App.createDUIBinding({
                                     async get() {
@@ -269,7 +268,7 @@ export const HomepageSettings = (stateManager:SourceStateManager, requestManager
                             App.createDUISelect({
                                 id: "sourceRowStyleSelect",
                                 label: "Style",
-                                options: Object.keys(rowStyles),
+                                options: rowStyles,
                                 allowsMultiselect: false,
                                 value: App.createDUIBinding({
                                     async get() {
@@ -292,10 +291,12 @@ export const HomepageSettings = (stateManager:SourceStateManager, requestManager
     })
 }
 
+// Category selection
 export const categoriesSettings = async (stateManager: SourceStateManager, requestManager: RequestManager): Promise<DUISelect> => {
     let serverCategories = await getServerCategories(stateManager);
     const serverURL = await getServerURL(stateManager);
 
+    // fetch categories only when the URL has been set
     if (serverURL !== DEFAULT_SERVER_URL){
         serverCategories = await fetchServerCategories(stateManager,requestManager)
         setServerCategories(stateManager, serverCategories)
@@ -311,19 +312,21 @@ export const categoriesSettings = async (stateManager: SourceStateManager, reque
         },
         value: App.createDUIBinding({
             async get() {
-                return (await getSelectedCategories(stateManager)) ?? DEFAULT_SELECTED_CATEGORIES
+                return (await getSelectedCategories(stateManager))
             },
             async set(newValue) {
-                await setSelectedCategories(stateManager, newValue?? DEFAULT_SELECTED_CATEGORIES)
+                await setSelectedCategories(stateManager, newValue)
             }
         }),
     })
 }
 
+// Source selection
 export const sourceSettings = async (stateManager : SourceStateManager, requestManager : RequestManager) : Promise<DUISelect> => {
     let serverSources = await getServerSources(stateManager);
     const serverURL = await getServerURL(stateManager);
 
+    // only fetches when url has been set
     if (serverURL !== DEFAULT_SERVER_URL){
         serverSources = await fetchServerSources(stateManager, requestManager)
         setServerSources(stateManager, serverSources)
@@ -335,7 +338,7 @@ export const sourceSettings = async (stateManager : SourceStateManager, requestM
         allowsMultiselect: true,
         options: getSourcesIds(serverSources),
         labelResolver: async (option) => {
-            return (await getSourceNameFromId(serverSources, option)) ?? DEFAULT_SELECTED_SOURCES
+            return getSourceNameFromId(serverSources, option)
         },
         value: App.createDUIBinding({
             async get() {
@@ -349,7 +352,6 @@ export const sourceSettings = async (stateManager : SourceStateManager, requestM
 }
 
 export const resetSettingsButton = async (stateManager : SourceStateManager) : Promise<DUIButton> => {
-
     return App.createDUIButton({
         id: "resetSettingsButton",
         label: "Reset Settings",

--- a/src/TachiDesk/Settings.ts
+++ b/src/TachiDesk/Settings.ts
@@ -7,50 +7,137 @@ import {
 } from "@paperback/types"
 
 import {
-    TachiAPIClass,
-    TachiCategoriesClass,
-    TachiSourcesClass
+    DEFAULT_SELECTED_CATEGORIES,
+    DEFAULT_SELECTED_SOURCES,
+    DEFAULT_SERVER_URL,
+    fetchServerCategories,
+    fetchServerSources,
+    getAuthState,
+    getCategoriesIds,
+    getCategoryNameFromId,
+    getCategoryRowState,
+    getCategoryRowStyle,
+    getMangaPerRow,
+    getPassword,
+    getSelectedCategories,
+    getSelectedSources,
+    getServerCategories,
+    getServerSources,
+    getServerURL,
+    getSourceNameFromId,
+    getSourceRowState,
+    getSourceRowStyle,
+    getSourcesIds,
+    getUpdatedRowState,
+    getUpdatedRowStyle,
+    getUsername,
+    resetSettings,
+    rowStyles,
+    setAuthState,
+    setCategoryRowState,
+    setCategoryRowStyle,
+    setMangaPerRow,
+    setPassword,
+    setSelectedCategories,
+    setSelectedSources,
+    setServerCategories,
+    setServerSources,
+    setServerURL,
+    setSourceRowState,
+    setSourceRowStyle,
+    setUpdatedRowState,
+    setUpdatedRowStyle,
+    setUsername,
+    styleResolver,
+    testRequest
 } from "./Common"
 
-export const serverAddressSettings = (stateManager: SourceStateManager, requestManager: RequestManager, tachiAPI: TachiAPIClass): DUINavigationButton => {
-    let label = "Click on the button!";
+export const serverAddressSettings = (stateManager: SourceStateManager, requestManager: RequestManager): DUINavigationButton => {
+    let label = "Click on the button!"
 
-    // Provides an input field, a button which sends a test request, and a label showing us the result of said request.
     return App.createDUINavigationButton({
-        id: "server_settings",
+        id: "serverSettings",
         label: "Server Settings",
         form: App.createDUIForm({
             sections: async () => {
+
                 return [
                     App.createDUISection({
-                        id: "server_address_section",
+                        id: "urlSection",
+                        header: "Server Address",
                         isHidden: false,
                         rows: async () => [
                             App.createDUIInputField({
-                                id: "server_address_input",
+                                id: "urlInputField",
                                 label: "Server URL",
                                 value: App.createDUIBinding({
                                     async get() {
-                                        return await tachiAPI.getServerAddress(stateManager);
+                                        return await getServerURL(stateManager)
                                     },
                                     async set(newValue) {
-                                        await tachiAPI.setServerAddress(stateManager, newValue)
+
+                                        await setServerURL(stateManager, newValue)
                                     }
                                 })
                             }),
                             App.createDUIButton({
-                                id: "test_server_button",
+                                id: "testServerButton",
                                 label: "Test Server",
                                 onTap: async () => {
-                                    const value = await tachiAPI.testRequest(requestManager);
+                                    const value = await testRequest(stateManager, requestManager)
 
                                     label = value instanceof Error ? value.message : JSON.stringify(value)
-
                                 }
                             }),
                             App.createDUILabel({
-                                id: "testing_button",
-                                label: label
+                                id: "test_label",
+                                label: label,
+                            })
+                        ]
+                    }),
+                    App.createDUISection({
+                        id: "authSettings",
+                        header: "Authentication",
+                        isHidden: false,
+                        rows: async () => [
+                            // Auth Switch
+                            App.createDUISwitch({
+                                id: "authStateSwitch",
+                                label: "Authorization Enabled",
+                                value: App.createDUIBinding({
+                                    async get() {
+                                        return await getAuthState(stateManager)
+                                    },
+                                    async set(newValue) {
+                                        await setAuthState(stateManager, newValue as boolean)
+                                    }
+                                })
+                            }),
+                            // Username
+                            App.createDUIInputField({
+                                id: "UsernameInputField",
+                                label: "Username",
+                                value: App.createDUIBinding({
+                                    async get() {
+                                        return await getUsername(stateManager)
+                                    },
+                                    async set(newValue) {
+                                        await setUsername(stateManager, newValue as string)
+                                    }
+                                })
+                            }),
+                            // Password
+                            App.createDUISecureInputField({
+                                id: "passwordInputField",
+                                label: "Password",
+                                value: App.createDUIBinding({
+                                    async get() {
+                                        return await getPassword(stateManager)
+                                    },
+                                    async set(newValue) {
+                                        await setPassword(stateManager, newValue as string)
+                                    }
+                                })
                             })
                         ]
                     })
@@ -60,89 +147,214 @@ export const serverAddressSettings = (stateManager: SourceStateManager, requestM
     })
 }
 
-export const selectedSourcesSettings = async (stateManager: SourceStateManager, requestManager: RequestManager, tachiAPI: TachiAPIClass, tachiSources: TachiSourcesClass): Promise<DUISelect> => {
-    try {
-        const tachiSourcesInitResponse = await tachiSources.init(stateManager, requestManager, tachiAPI)
-        if (tachiSourcesInitResponse instanceof Error) {
-            throw tachiSourcesInitResponse;
-        }
-
-        tachiSources = tachiSourcesInitResponse
-    }
-    catch (error: any) { }
-
-    // Provides a multiselectable list of sources
-    return App.createDUISelect({
-        id: "selected_sources_settings",
-        label: "Sources",
-        allowsMultiselect: true,
-        options: Object.keys(tachiSources.getAllSources()),
-        labelResolver: async (option) => tachiSources.getAllSources()[option]["displayName"],
-        value: App.createDUIBinding({
-            async get() {
-                return (await tachiSources.getSelectedSources(stateManager));
-            },
-            async set(newValue) {
-                await tachiSources.setSelectedSources(stateManager, newValue)
+export const HomepageSettings = (stateManager:SourceStateManager, requestManager: RequestManager): DUINavigationButton => {
+    
+    return App.createDUINavigationButton({
+        id: "homepageSettings",
+        label: "Homepage Settings",
+        form: App.createDUIForm({
+            sections: async () => {
+                
+                return [
+                    App.createDUISection({
+                        id: "mangaPerRowSection",
+                        header: "Manga Per Row",
+                        isHidden: false,
+                        rows: async () => [
+                            App.createDUIStepper({
+                                id: "mangaPerRowStepper",
+                                label: "",
+                                min: 0,
+                                value: App.createDUIBinding({
+                                    async get() {
+                                        return await getMangaPerRow(stateManager)
+                                    },
+                                    async set(newValue) {
+                                        await setMangaPerRow(stateManager, newValue)
+                                    }
+                                })
+                            })
+                        ]
+                    }),
+                    App.createDUISection({
+                        id: "updatedRowSection",
+                        header: "Updated Feed",
+                        isHidden: false,
+                        rows: async () => [
+                            App.createDUISwitch({
+                                id: "updatedRowStateSwitch",
+                                label: "Show",
+                                value: App.createDUIBinding({
+                                    async get() {
+                                        return await getUpdatedRowState(stateManager)
+                                    },
+                                    async set(newValue) {
+                                        await setUpdatedRowState(stateManager, newValue)
+                                    }
+                                })
+                            }),
+                            App.createDUISelect({
+                                id: "updatedRowStyleSelect",
+                                label: "Style",
+                                options: Object.keys(rowStyles),
+                                allowsMultiselect: false,
+                                value: App.createDUIBinding({
+                                    async get() {
+                                        return await getUpdatedRowStyle(stateManager)
+                                    },
+                                    async set(newValue) {
+                                        await setUpdatedRowStyle(stateManager, newValue)
+                                    }
+                                }),
+                                labelResolver: async (option) => {
+                                    return styleResolver(option); 
+                                },
+                            })
+                        ]
+                    }),
+                    App.createDUISection({
+                        id: "categoryRowSection",
+                        header: "Library Categories",
+                        isHidden: false,
+                        rows: async () => [
+                            App.createDUISwitch({
+                                id: "categoryRowStateSwitch",
+                                label: "Show",
+                                value: App.createDUIBinding({
+                                    async get() {
+                                        return await getCategoryRowState(stateManager)
+                                    },
+                                    async set(newValue) {
+                                        await setCategoryRowState(stateManager, newValue)
+                                    }
+                                })
+                            }),
+                            App.createDUISelect({
+                                id: "categoryRowStyleSelect",
+                                label: "Style",
+                                options: Object.keys(rowStyles),
+                                allowsMultiselect: false,
+                                value: App.createDUIBinding({
+                                    async get() {
+                                        return await getCategoryRowStyle(stateManager)
+                                    },
+                                    async set(newValue) {
+                                        await setCategoryRowStyle(stateManager, newValue)
+                                    }
+                                }),
+                                labelResolver: async (option) => {
+                                    return styleResolver(option); 
+                                },
+                            }),
+                            await categoriesSettings(stateManager,requestManager)
+                        ]
+                    }),
+                    App.createDUISection({
+                        id: "sourceRowSection",
+                        header: "Sources",
+                        isHidden: false,
+                        rows: async () => [
+                            App.createDUISwitch({
+                                id: "sourceRowStateSwitch",
+                                label: "Show",
+                                value: App.createDUIBinding({
+                                    async get() {
+                                        return await getSourceRowState(stateManager)
+                                    },
+                                    async set(newValue) {
+                                        await setSourceRowState(stateManager, newValue)
+                                    }
+                                })
+                            }),
+                            App.createDUISelect({
+                                id: "sourceRowStyleSelect",
+                                label: "Style",
+                                options: Object.keys(rowStyles),
+                                allowsMultiselect: false,
+                                value: App.createDUIBinding({
+                                    async get() {
+                                        return await getSourceRowStyle(stateManager)
+                                    },
+                                    async set(newValue) {
+                                        await setSourceRowStyle(stateManager, newValue)
+                                    }
+                                }),
+                                labelResolver: async (option) => {
+                                    return styleResolver(option); 
+                                },
+                            }),
+                            await sourceSettings(stateManager,requestManager)
+                        ]
+                    })
+                ]
             }
         })
     })
 }
 
+export const categoriesSettings = async (stateManager: SourceStateManager, requestManager: RequestManager): Promise<DUISelect> => {
+    let serverCategories = await getServerCategories(stateManager);
+    const serverURL = await getServerURL(stateManager);
 
-export const selectedCategoriesSettings = async (stateManager: SourceStateManager, requestManager: RequestManager, tachiAPI: TachiAPIClass, tachiCategories: TachiCategoriesClass): Promise<DUISelect> => {
-    try {
-        const tachiCategoriesInitResponse = await tachiCategories.init(stateManager, requestManager, tachiAPI)
-
-        if (tachiCategoriesInitResponse instanceof Error) {
-            throw tachiCategoriesInitResponse;
-        }
-
-        tachiCategories = tachiCategoriesInitResponse
-    }
-    catch (error) {
-
+    if (serverURL !== DEFAULT_SERVER_URL){
+        serverCategories = await fetchServerCategories(stateManager,requestManager)
+        setServerCategories(stateManager, serverCategories)
     }
 
-    // Provides a multiselectable list of categories
     return App.createDUISelect({
-        id: "selected_categories_settings",
+        id: "CategoriesSelection",
         label: "Categories",
         allowsMultiselect: true,
-        options: Object.keys(tachiCategories.getAllCategories()),
-        labelResolver: async (option) => tachiCategories.getSelectedCategoryFromId(option),
+        options: getCategoriesIds(serverCategories),
+        labelResolver: async (option) => {
+            return getCategoryNameFromId(serverCategories, option) ?? ""
+        },
         value: App.createDUIBinding({
             async get() {
-                return await tachiCategories.getSelectedCategories(stateManager);
+                return (await getSelectedCategories(stateManager)) ?? DEFAULT_SELECTED_CATEGORIES
             },
             async set(newValue) {
-                await tachiCategories.setSelectedCategories(stateManager, newValue);
+                await setSelectedCategories(stateManager, newValue?? DEFAULT_SELECTED_CATEGORIES)
+            }
+        }),
+    })
+}
+
+export const sourceSettings = async (stateManager : SourceStateManager, requestManager : RequestManager) : Promise<DUISelect> => {
+    let serverSources = await getServerSources(stateManager);
+    const serverURL = await getServerURL(stateManager);
+
+    if (serverURL !== DEFAULT_SERVER_URL){
+        serverSources = await fetchServerSources(stateManager, requestManager)
+        setServerSources(stateManager, serverSources)
+    }
+
+    return App.createDUISelect({
+        id: "SourcesSelection",
+        label: "Sources",
+        allowsMultiselect: true,
+        options: getSourcesIds(serverSources),
+        labelResolver: async (option) => {
+            return (await getSourceNameFromId(serverSources, option)) ?? DEFAULT_SELECTED_SOURCES
+        },
+        value: App.createDUIBinding({
+            async get() {
+                return await getSelectedSources(stateManager)
+            },
+            async set(newValue) {
+                await setSelectedSources(stateManager, newValue)
             }
         })
     })
 }
 
-// Button that's supposed to reset all settings.
-// Seems to be currently broken (8-1-23) [m/d/yyyy].
-export const resetSettingsButton = async (stateManager: SourceStateManager, tachiAPI: TachiAPIClass, tachiSources: TachiSourcesClass, tachiCategories: TachiCategoriesClass): Promise<DUIButton> => {
+export const resetSettingsButton = async (stateManager : SourceStateManager) : Promise<DUIButton> => {
+
     return App.createDUIButton({
-        id: "reset_button",
-        label: "Reset to Default",
-        onTap: async () => {
-            await tachiAPI.setServerAddress(stateManager, "http://127.0.0.1:4567")
-            await tachiSources.setSelectedSources(stateManager, ["0"])
-            await tachiCategories.setSelectedCategories(stateManager, ["0"])
-            await tachiSources.setAllSources(stateManager, {
-                "0": {
-                    "name": "Local source",
-                    "lang": "localsourcelang",
-                    "iconUrl": "/api/v1/extension/icon/localSource",
-                    "supportsLatest": true,
-                    "isConfigurable": false,
-                    "isNsfw": false,
-                    "displayName": "Local source"
-                }
-            })
+        id: "resetSettingsButton",
+        label: "Reset Settings",
+        onTap:async () => {
+            await resetSettings(stateManager)
         }
     })
 }

--- a/src/TachiDesk/Settings.ts
+++ b/src/TachiDesk/Settings.ts
@@ -246,7 +246,6 @@ export const HomepageSettings = (stateManager: SourceStateManager, requestManage
                                     return styleResolver(option);
                                 },
                             }),
-                            await categoriesSettings(stateManager, requestManager)
                         ]
                     }),
                     App.createDUISection({
@@ -283,8 +282,6 @@ export const HomepageSettings = (stateManager: SourceStateManager, requestManage
                                     return styleResolver(option);
                                 },
                             }),
-                            await languageSettings(stateManager),
-                            await sourceSettings(stateManager, requestManager)
                         ]
                     })
                 ]

--- a/src/TachiDesk/Settings.ts
+++ b/src/TachiDesk/Settings.ts
@@ -129,20 +129,20 @@ export const resetSettingsButton = async (stateManager: SourceStateManager, tach
         id: "reset_button",
         label: "Reset to Default",
         onTap: async () => {
-                await tachiAPI.setServerAddress(stateManager, "http://127.0.0.1:4567")
-                await tachiSources.setSelectedSources(stateManager, ["0"])
-                await tachiCategories.setSelectedCategories(stateManager, ["0"])
-                await tachiSources.setAllSources(stateManager, {
-                    "0": {
-                        "name": "Local source",
-                        "lang": "localsourcelang",
-                        "iconUrl": "/api/v1/extension/icon/localSource",
-                        "supportsLatest": true,
-                        "isConfigurable": false,
-                        "isNsfw": false,
-                        "displayName": "Local source"
-                    }
-                })
+            await tachiAPI.setServerAddress(stateManager, "http://127.0.0.1:4567")
+            await tachiSources.setSelectedSources(stateManager, ["0"])
+            await tachiCategories.setSelectedCategories(stateManager, ["0"])
+            await tachiSources.setAllSources(stateManager, {
+                "0": {
+                    "name": "Local source",
+                    "lang": "localsourcelang",
+                    "iconUrl": "/api/v1/extension/icon/localSource",
+                    "supportsLatest": true,
+                    "isConfigurable": false,
+                    "isNsfw": false,
+                    "displayName": "Local source"
+                }
+            })
         }
     })
 }

--- a/src/TachiDesk/Settings.ts
+++ b/src/TachiDesk/Settings.ts
@@ -80,7 +80,7 @@ export const selectedSourcesSettings = async (stateManager: SourceStateManager, 
         labelResolver: async (option) => tachiSources.getAllSources()[option]["displayName"],
         value: App.createDUIBinding({
             async get() {
-                return await tachiSources.getSelectedSources(stateManager);
+                return (await tachiSources.getSelectedSources(stateManager));
             },
             async set(newValue) {
                 await tachiSources.setSelectedSources(stateManager, newValue)
@@ -124,17 +124,15 @@ export const selectedCategoriesSettings = async (stateManager: SourceStateManage
 
 // Button that's supposed to reset all settings.
 // Seems to be currently broken (8-1-23) [m/d/yyyy].
-export const resetSettingsButton = (stateManager: SourceStateManager, tachiAPI: TachiAPIClass, tachiSources: TachiSourcesClass, tachiCategories: TachiCategoriesClass): DUIButton => {
+export const resetSettingsButton = async (stateManager: SourceStateManager, tachiAPI: TachiAPIClass, tachiSources: TachiSourcesClass, tachiCategories: TachiCategoriesClass): Promise<DUIButton> => {
     return App.createDUIButton({
         id: "reset_button",
         label: "Reset to Default",
         onTap: async () => {
-            await Promise.all([
-                await tachiAPI.setServerAddress(stateManager, null),
-                await tachiSources.setSelectedSources(stateManager, null),
-                await tachiCategories.setSelectedCategories(stateManager, null),
-                await tachiSources.setAllSources(stateManager, null)
-            ])
+                await tachiAPI.setServerAddress(stateManager, undefined)
+                await tachiSources.setSelectedSources(stateManager, undefined)
+                await tachiCategories.setSelectedCategories(stateManager, undefined)
+                await tachiSources.setAllSources(stateManager, undefined)
         }
     })
 }

--- a/src/TachiDesk/Settings.ts
+++ b/src/TachiDesk/Settings.ts
@@ -154,7 +154,7 @@ export const serverAddressSettings = (stateManager: SourceStateManager, requestM
 
 // Houses settings for Manga Per Row, and settings for each type of homepage section (recently updated, library category, and source )
 // for sections -> You can toggle them, change their style, change their content (which category/source)
-export const HomepageSettings = (stateManager:SourceStateManager, requestManager: RequestManager): DUINavigationButton => {
+export const HomepageSettings = (stateManager: SourceStateManager, requestManager: RequestManager): DUINavigationButton => {
     return App.createDUINavigationButton({
         id: "homepageSettings",
         label: "Homepage Settings",
@@ -214,7 +214,7 @@ export const HomepageSettings = (stateManager:SourceStateManager, requestManager
                                     }
                                 }),
                                 labelResolver: async (option) => {
-                                    return styleResolver(option); 
+                                    return styleResolver(option);
                                 },
                             })
                         ]
@@ -250,10 +250,10 @@ export const HomepageSettings = (stateManager:SourceStateManager, requestManager
                                     }
                                 }),
                                 labelResolver: async (option) => {
-                                    return styleResolver(option); 
+                                    return styleResolver(option);
                                 },
                             }),
-                            await categoriesSettings(stateManager,requestManager)
+                            await categoriesSettings(stateManager, requestManager)
                         ]
                     }),
                     App.createDUISection({
@@ -287,11 +287,11 @@ export const HomepageSettings = (stateManager:SourceStateManager, requestManager
                                     }
                                 }),
                                 labelResolver: async (option) => {
-                                    return styleResolver(option); 
+                                    return styleResolver(option);
                                 },
                             }),
                             await languageSettings(stateManager),
-                            await sourceSettings(stateManager,requestManager)
+                            await sourceSettings(stateManager, requestManager)
                         ]
                     })
                 ]
@@ -307,8 +307,8 @@ export const categoriesSettings = async (stateManager: SourceStateManager, reque
 
     // Gets the selected categories, checks if they're in the options. If they're not, add them to a list added to the options later
     // Ensures that user can delete an old option.
-    for (const id of await getSelectedCategories(stateManager)){
-        if(!(getCategoriesIds(serverCategories).includes(id))){
+    for (const id of await getSelectedCategories(stateManager)) {
+        if (!(getCategoriesIds(serverCategories).includes(id))) {
             missedSelected.push(id)
         }
     }
@@ -333,7 +333,7 @@ export const categoriesSettings = async (stateManager: SourceStateManager, reque
 }
 
 // Source selection
-export const sourceSettings = async (stateManager : SourceStateManager, requestManager : RequestManager) : Promise<DUISelect> => {
+export const sourceSettings = async (stateManager: SourceStateManager, requestManager: RequestManager): Promise<DUISelect> => {
     let serverSources = await getServerSources(stateManager);
     let missedSelected = []
     const languages = await getSelectedLanguages(stateManager)
@@ -347,9 +347,9 @@ export const sourceSettings = async (stateManager : SourceStateManager, requestM
 
     // Gets the selected sources, checks if they're in the options. If they're not, add them to a list added to the options later
     // Ensures that user can delete an old option.
-    for (const id of options.concat(await getSelectedSources(stateManager))){
+    for (const id of options.concat(await getSelectedSources(stateManager))) {
         console.log(id + ": " + JSON.stringify(getSourcesIds(serverSources).includes(id)))
-        if(!(getSourcesIds(serverSources).includes(id))){
+        if (!(getSourcesIds(serverSources).includes(id))) {
             missedSelected.push(id)
         }
     }
@@ -388,16 +388,16 @@ export const languageSettings = async (stateManager: SourceStateManager): Promis
             },
             async set(newValue) {
                 await setSelectedLanguages(stateManager, newValue)
-            }        
+            }
         }),
     })
 }
 
-export const resetSettingsButton = async (stateManager : SourceStateManager) : Promise<DUIButton> => {
+export const resetSettingsButton = async (stateManager: SourceStateManager): Promise<DUIButton> => {
     return App.createDUIButton({
         id: "resetSettingsButton",
         label: "Reset Settings",
-        onTap:async () => {
+        onTap: async () => {
             await resetSettings(stateManager)
         }
     })

--- a/src/TachiDesk/Settings.ts
+++ b/src/TachiDesk/Settings.ts
@@ -129,10 +129,20 @@ export const resetSettingsButton = async (stateManager: SourceStateManager, tach
         id: "reset_button",
         label: "Reset to Default",
         onTap: async () => {
-                await tachiAPI.setServerAddress(stateManager, undefined)
-                await tachiSources.setSelectedSources(stateManager, undefined)
-                await tachiCategories.setSelectedCategories(stateManager, undefined)
-                await tachiSources.setAllSources(stateManager, undefined)
+                await tachiAPI.setServerAddress(stateManager, "http://127.0.0.1:4567")
+                await tachiSources.setSelectedSources(stateManager, ["0"])
+                await tachiCategories.setSelectedCategories(stateManager, ["0"])
+                await tachiSources.setAllSources(stateManager, {
+                    "0": {
+                        "name": "Local source",
+                        "lang": "localsourcelang",
+                        "iconUrl": "/api/v1/extension/icon/localSource",
+                        "supportsLatest": true,
+                        "isConfigurable": false,
+                        "isNsfw": false,
+                        "displayName": "Local source"
+                    }
+                })
         }
     })
 }

--- a/src/TachiDesk/Settings.ts
+++ b/src/TachiDesk/Settings.ts
@@ -8,6 +8,8 @@ import {
 
 import {
     DEFAULT_SERVER_SOURCE,
+    fetchServerCategories,
+    fetchServerSources,
     getAuthState,
     getCategoriesIds,
     getCategoryNameFromId,
@@ -41,6 +43,8 @@ import {
     setSelectedCategories,
     setSelectedLanguages,
     setSelectedSources,
+    setServerCategories,
+    setServerSources,
     setServerURL,
     setSourceRowState,
     setSourceRowStyle,
@@ -75,8 +79,9 @@ export const serverAddressSettings = (stateManager: SourceStateManager, requestM
                                         return await getServerURL(stateManager)
                                     },
                                     async set(newValue) {
-
                                         await setServerURL(stateManager, newValue)
+                                        await setServerSources(stateManager, await fetchServerSources(stateManager, requestManager))
+                                        await setServerCategories(stateManager, await fetchServerCategories(stateManager, requestManager))
                                     }
                                 })
                             }),
@@ -85,7 +90,6 @@ export const serverAddressSettings = (stateManager: SourceStateManager, requestM
                                 label: "Test Server",
                                 onTap: async () => {
                                     const value = await testRequest(stateManager, requestManager)
-
                                     label = value instanceof Error ? value.message : JSON.stringify(value)
                                 }
                             }),

--- a/src/TachiDesk/Settings.ts
+++ b/src/TachiDesk/Settings.ts
@@ -304,16 +304,6 @@ export const HomepageSettings = (stateManager:SourceStateManager, requestManager
 export const categoriesSettings = async (stateManager: SourceStateManager, requestManager: RequestManager): Promise<DUISelect> => {
     let serverCategories = await getServerCategories(stateManager);
     let missedSelected = []
-    const serverURL = await getServerURL(stateManager);
-
-    // fetch categories only when the URL has been set
-    if (serverURL !== DEFAULT_SERVER_URL){
-        const fetchedCategories = await fetchServerCategories(stateManager,requestManager)
-        if(JSON.stringify(fetchedCategories) !== JSON.stringify(serverCategories)){
-            serverCategories = fetchedCategories
-            setServerCategories(stateManager, serverCategories)
-        }
-    }
 
     // Gets the selected categories, checks if they're in the options. If they're not, add them to a list added to the options later
     // Ensures that user can delete an old option.
@@ -346,18 +336,7 @@ export const categoriesSettings = async (stateManager: SourceStateManager, reque
 export const sourceSettings = async (stateManager : SourceStateManager, requestManager : RequestManager) : Promise<DUISelect> => {
     let serverSources = await getServerSources(stateManager);
     let missedSelected = []
-    const serverURL = await getServerURL(stateManager);
     const languages = await getSelectedLanguages(stateManager)
-
-
-    // only fetches when url has been set, only sets the fetched when the old record is different 
-    if (serverURL !== DEFAULT_SERVER_URL){
-        const fetchedServerSources = await fetchServerSources(stateManager, requestManager)
-        if (JSON.stringify(fetchedServerSources) !== JSON.stringify(serverSources)){
-            serverSources = fetchedServerSources
-            setServerSources(stateManager, serverSources)
-        }
-    }
 
     // Clean sources based on selected languages
     // getSourcesIds(serverSources).concat(missedSelected)
@@ -374,8 +353,7 @@ export const sourceSettings = async (stateManager : SourceStateManager, requestM
             missedSelected.push(id)
         }
     }
-    console.log(JSON.stringify(options))
-    console.log(JSON.stringify(missedSelected))
+
     return App.createDUISelect({
         id: "SourcesSelection",
         label: "Sources",

--- a/src/TachiDesk/Settings.ts
+++ b/src/TachiDesk/Settings.ts
@@ -8,9 +8,6 @@ import {
 
 import {
     DEFAULT_SERVER_SOURCE,
-    DEFAULT_SERVER_URL,
-    fetchServerCategories,
-    fetchServerSources,
     getAuthState,
     getCategoriesIds,
     getCategoryNameFromId,
@@ -44,8 +41,6 @@ import {
     setSelectedCategories,
     setSelectedLanguages,
     setSelectedSources,
-    setServerCategories,
-    setServerSources,
     setServerURL,
     setSourceRowState,
     setSourceRowStyle,
@@ -205,11 +200,9 @@ export const HomepageSettings = (stateManager: SourceStateManager, requestManage
                                 allowsMultiselect: false,
                                 value: App.createDUIBinding({
                                     async get() {
-                                        console.log("get: " + JSON.stringify(await getUpdatedRowStyle(stateManager)))
                                         return await getUpdatedRowStyle(stateManager)
                                     },
                                     async set(newValue) {
-                                        console.log("set: " + JSON.stringify(newValue))
                                         await setUpdatedRowStyle(stateManager, newValue)
                                     }
                                 }),
@@ -348,7 +341,6 @@ export const sourceSettings = async (stateManager: SourceStateManager, requestMa
     // Gets the selected sources, checks if they're in the options. If they're not, add them to a list added to the options later
     // Ensures that user can delete an old option.
     for (const id of options.concat(await getSelectedSources(stateManager))) {
-        console.log(id + ": " + JSON.stringify(getSourcesIds(serverSources).includes(id)))
         if (!(getSourcesIds(serverSources).includes(id))) {
             missedSelected.push(id)
         }

--- a/src/TachiDesk/TachiDesk.ts
+++ b/src/TachiDesk/TachiDesk.ts
@@ -31,7 +31,7 @@ import {
     serverAddressSettings
 } from './Settings';
 
-export const TachideskInfo: SourceInfo = {
+export const TachiDeskInfo: SourceInfo = {
     author: 'ofelizestevez & Alles',
     description: 'Paperback extension which aims to bridge all of Tachidesks features and the Paperback App.',
     icon: 'icon.png',
@@ -48,7 +48,7 @@ export const TachideskInfo: SourceInfo = {
     intents: SourceIntents.MANGA_CHAPTERS | SourceIntents.SETTINGS_UI | SourceIntents.HOMEPAGE_SECTIONS
 }
 
-export class Tachidesk implements HomePageSectionsProviding, ChapterProviding, SearchResultsProviding {
+export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, SearchResultsProviding {
 
     // Paperback required defaults
     // Statemanager saves states for the extension (like localstorage api)

--- a/src/TachiDesk/TachiDesk.ts
+++ b/src/TachiDesk/TachiDesk.ts
@@ -1,44 +1,63 @@
 import {
+    BadgeColor,
     Chapter,
     ChapterDetails,
-    PagedResults,
-    SourceManga,
-    HomeSection,
-    SearchRequest,
-    SourceInfo,
-    ContentRating,
-    TagSection,
-    HomeSectionType,
     ChapterProviding,
-    SourceIntents,
+    ContentRating,
     DUISection,
-    SearchResultsProviding,
     HomePageSectionsProviding,
-    BadgeColor,
-} from '@paperback/types'
+    HomeSection,
+    HomeSectionType,
+    PagedResults,
+    SearchRequest,
+    SearchResultsProviding,
+    SourceInfo,
+    SourceIntents,
+    SourceManga,
+    TagSection
+} from "@paperback/types"
 
-import {
-    TachiAPIClass,
-    TachiCategoriesClass,
-    TachiSourcesClass,
-    serverUnavailableMangaTiles
-} from './Common';
-
-import {
+import { 
+    HomepageSettings,
     resetSettingsButton,
-    selectedCategoriesSettings,
-    selectedSourcesSettings,
-    serverAddressSettings
-} from './Settings';
+    serverAddressSettings,
+} from "./Settings";
 
+import { 
+    CATEGORY_ROW_STATE_KEY,
+    CATEGORY_ROW_STYLE_KEY, 
+    MANGA_PER_ROW_KEY, 
+    SELECTED_CATEGORIES_KEY, 
+    SOURCE_ROW_STATE_KEY, 
+    SOURCE_ROW_STYLE_KEY, 
+    UPDATED_ROW_STATE_KEY, 
+    UPDATED_ROW_STYLE_KEY, 
+    fetchServerCategories, 
+    getCategoryFromId, 
+    getCategoryNameFromId, 
+    getSelectedSources, 
+    getServerAPI, 
+    getServerSources, 
+    getServerURL, 
+    getSourceFromId, 
+    getSourceNameFromId, 
+    makeRequest, 
+    serverUnavailableMangaTiles, 
+    tachiChapter, 
+    tachiManga,
+    testRequest } from "./Common";
+
+// * New 2.0 Version is a rewrite due to it being broken on the new 0.8.7 Builds
+// ! It's broken cause of iOS, gg me and not having an https server
+// ! Atleast this is smoother than last version (other than the settings, all my homies hate JSManagedValue)
 export const TachiDeskInfo: SourceInfo = {
     author: 'ofelizestevez & Alles',
     description: 'Paperback extension which aims to bridge all of Tachidesks features and the Paperback App.',
     icon: 'icon.png',
     name: 'Tachidesk',
-    version: '1.1',
+    version: '2.0-beta',
     websiteBaseURL: "https://github.com/Suwayomi/Tachidesk-Server",
-    contentRating: ContentRating.EVERYONE,
+    contentRating: ContentRating.ADULT,
     sourceTags: [
         {
             text: "Self-hosted",
@@ -49,128 +68,97 @@ export const TachiDeskInfo: SourceInfo = {
 }
 
 export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, SearchResultsProviding {
-
-    // Paperback required defaults
-    // Statemanager saves states for the extension (like localstorage api)
-    // Request manager makes HTTP requests
     stateManager = App.createSourceStateManager();
     requestManager = App.createRequestManager({
         requestsPerSecond: 4,
-        requestTimeout: 20000,
-    });
+        requestTimeout: 20000
+    })
 
-    // Tachidesk essentials. Packages up code neatly so it could be used in multiple places cleanly
-    // TachiAPI handles the server address and making requests
-    // TachiSources and TachiCategories handle library items (sources, categories)
-    tachiAPI = new TachiAPIClass().init(this.stateManager);
-    tachiSources = new TachiSourcesClass();
-    tachiCategories = new TachiCategoriesClass();
-
-    // Variable used for getMangaShareUrl. Updated by getChapters, meaning that it updates the server address everytime the user opens a manga
-    // Technically it doesn't have to be updated this often, thus it has room for improvement
     serverAddress = ""
 
-    // Provides the settings for the extension
     async getSourceMenu(): Promise<DUISection> {
-        const tachiAPI = await this.tachiAPI;
         return App.createDUISection({
             id: "main",
             header: "Source Settings",
             isHidden: false,
             rows: async () => [
-                serverAddressSettings(this.stateManager, this.requestManager, tachiAPI),
-                await selectedSourcesSettings(this.stateManager, this.requestManager, tachiAPI, this.tachiSources),
-                await selectedCategoriesSettings(this.stateManager, this.requestManager, tachiAPI, this.tachiCategories),
-                await resetSettingsButton(this.stateManager, tachiAPI, this.tachiSources, this.tachiCategories),
+                serverAddressSettings(this.stateManager, this.requestManager),
+                HomepageSettings(this.stateManager, this.requestManager),
+                await resetSettingsButton(this.stateManager)
             ]
         })
     }
 
-    // Provides share url for manga share button, if statement seems to not work
     getMangaShareUrl(mangaId: string): string {
-        if (this.serverAddress != "") {
-            return this.serverAddress + "/manga/" + mangaId
+        if (this.serverAddress != ""){
+            return this.serverAddress + "manga/" + mangaId
         }
         return ""
     }
 
-    // Provides paperback with all of the details of the manga
     async getMangaDetails(mangaId: string): Promise<SourceManga> {
-        const tachiAPI = await this.tachiAPI;
-
-        const manga = await tachiAPI.makeRequest(this.requestManager, "/manga/" + mangaId)
-        // throw new Error(this.serverAddress)
-        const image = await tachiAPI.getServerAddress(this.stateManager) + manga.thumbnailUrl;
-
-        const artist = manga.artist;
-        const author = manga.author;
-        const desc = manga.description;
-        const status = manga.status;
-        const titles = [manga.title];
-        const tags: [TagSection] = [
+        const manga : tachiManga = await makeRequest(this.stateManager, this.requestManager, "manga/" + mangaId)
+        const tags : [TagSection] = [
             App.createTagSection({
-                id: "0", label: "genres", tags:
-                    manga.genre.map((tag: string) => App.createTag({
-                        id: tag,
-                        label: tag
-                    }))
-            }),
-        ];
-
+                id: "0",
+                label: "genres",
+                tags: manga.genre.map((tag : string) => App.createTag({
+                    id: tag,
+                    label: tag
+                }))
+            })
+        ]
         return App.createSourceManga({
             id: mangaId,
             mangaInfo: App.createMangaInfo({
-                titles,
-                image,
-                author,
-                artist,
-                desc,
-                status,
+                titles: [manga.title],
+                image: (await getServerURL(this.stateManager)) + manga.thumbnailUrl.slice(1),
+                author: manga.author,
+                artist: manga.artist,
+                desc: manga.description,
+                status: manga.status,
                 tags
             })
         })
     }
-
-    // Provides paperback with list of chapters, updates this.serverAddress
     async getChapters(mangaId: string): Promise<Chapter[]> {
-        const tachiAPI = await this.tachiAPI
-
-        const chaptersData = await tachiAPI.makeRequest(this.requestManager, "/manga/" + mangaId + "/chapters")
-        this.serverAddress = await tachiAPI.getServerAddress(this.stateManager)
+        const chaptersData : tachiChapter[] = await makeRequest(this.stateManager, this.requestManager, "manga/" + mangaId + "/chapters")
+        this.serverAddress = await getServerURL(this.stateManager)
 
         const chapters: Chapter[] = []
 
-
-        for (const chapter of chaptersData) {
-            const id = String(chapter.index);
-            const chapNum = parseFloat(chapter.chapterNumber);
-            const name = chapter.name;
-            const time = new Date(chapter.uploadDate);
-            const sortingIndex = chapter.index;
-
+        for (const chapter of chaptersData){
             chapters.push(
                 App.createChapter({
-                    id,
-                    name,
-                    chapNum,
-                    time,
-                    sortingIndex
+                    id: chapter.index.toString(),
+                    name: chapter.name,
+                    chapNum: chapter.chapterNumber,
+                    time: new Date(chapter.uploadDate),
+                    sortingIndex: chapter.index
                 })
             )
         }
 
         return chapters
     }
-
-    // Called when user opens a manga. It's used to get the page links
     async getChapterDetails(mangaId: string, chapterId: string): Promise<ChapterDetails> {
-        const tachiAPI = await this.tachiAPI
+        const apiURL = await getServerAPI(this.stateManager)
+        const chapterData : tachiChapter = await makeRequest(this.stateManager, this.requestManager, "manga/" + mangaId + "/chapter/" + chapterId)
+        await makeRequest(this.stateManager,this.requestManager, "manga/" + mangaId + "/chapter/" + chapterId, "PUT", 
+        {
+            "read": "true",
+            "bookmarked": "",
+            "markPrevRead": "",
+            "lastPageRead": ""
+        },
+        {
+            "Content-Type": "application/json",
+        })
 
-        const chapterResponse = await tachiAPI.makeRequest(this.requestManager, "/manga/" + mangaId + "/chapter/" + chapterId)
-        const pages: string[] = []
+        const pages : string[] = []
 
-        for (const pageIndex of Array(chapterResponse.pageCount).keys()) {
-            pages.push(tachiAPI.getBaseURL() + "/manga/" + mangaId + "/chapter/" + chapterId + "/page/" + pageIndex)
+        for ( const pageIndex of Array(chapterData.pageCount).keys()){
+            pages.push(apiURL + "manga/" + mangaId + "/chapter/" + chapterId + "/page/" + pageIndex)
         }
 
         return App.createChapterDetails({
@@ -180,259 +168,234 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
         })
     }
 
-    // Builds the homepage sections. It handles "Updated", "Categories", and "Sources" all by itself.
-    // Could be divided into multiple functions.
     async getHomePageSections(sectionCallback: (section: HomeSection) => void): Promise<void> {
         const promises: Promise<void>[] = []
         const sections = []
-        const tachiAPI = await this.tachiAPI
-
-        const tachiSources = await this.tachiSources.init(this.stateManager, this.requestManager, tachiAPI)
-        const tachiCategories = await this.tachiCategories.init(this.stateManager, this.requestManager, tachiAPI)
-
-        // If we get a bad request, it will give us a server error manga tile.
-        if (tachiSources instanceof Error) {
+        
+        // Error Checking here!!!
+        if (await testRequest(this.stateManager, this.requestManager) instanceof Error){
             const section = App.createHomeSection({
                 id: "unset",
                 title: "Server Error",
                 containsMoreItems: false,
-                type: HomeSectionType.singleRowNormal,
-                items: serverUnavailableMangaTiles()
-            });
-            sectionCallback(section);
-            return;
-        }
-        if (tachiCategories instanceof Error) {
-            const section = App.createHomeSection({
-                id: "unset",
-                title: "Server Error",
-                containsMoreItems: false,
-                type: HomeSectionType.singleRowNormal,
+                type: "singleRowNormal",
                 items: serverUnavailableMangaTiles()
             });
             sectionCallback(section);
             return;
         }
 
-        // Last test to ensure that we can connect to the server
-        if ((await this.tachiAPI).makeRequest(this.requestManager, "/settings/about") instanceof Error) {
-            const section = App.createHomeSection({
-                id: "unset",
-                title: "Server Error",
-                containsMoreItems: false,
-                type: HomeSectionType.singleRowNormal,
-                items: serverUnavailableMangaTiles()
-            });
-            sectionCallback(section);
-            return;
-        }
-
-        // Updated featured Section
-        sections.push({
-            section: App.createHomeSection({
-                id: "updated",
-                title: "Last Updated",
-                containsMoreItems: true,
-                type: HomeSectionType.singleRowNormal
-            }),
-            request: App.createRequest({
-                url: tachiAPI.getBaseURL() + "/update/recentChapters/0",
-                method: "GET"
-            }),
-            subtitle: "",
-            type: "update"
-        })
-
-        // Category Sections
-        for (const categoryId of await tachiCategories.getSelectedCategories(this.stateManager)) {
+        const mangaPerRow = await this.stateManager.retrieve(MANGA_PER_ROW_KEY);
+        const updatedRowState = await this.stateManager.retrieve(UPDATED_ROW_STATE_KEY);
+        const categoryRowState = await this.stateManager.retrieve(CATEGORY_ROW_STATE_KEY);
+        const sourceRowState = await this.stateManager.retrieve(SOURCE_ROW_STATE_KEY);
+        
+        const updatedRowStyle = await this.stateManager.retrieve(UPDATED_ROW_STYLE_KEY);
+        const categoryRowStyle = await this.stateManager.retrieve(CATEGORY_ROW_STYLE_KEY);
+        const sourceRowStyle = await this.stateManager.retrieve(SOURCE_ROW_STYLE_KEY);
+        // Push Sections
+        // First point where we could break, depending on if the type comes out correctly or not.
+        if (updatedRowState){
             sections.push({
                 section: App.createHomeSection({
-                    id: "category-" + categoryId,
-                    title: tachiCategories.getSelectedCategoryFromId(categoryId.toString()),
+                    id: "updated",
+                    title: "Last Updated",
                     containsMoreItems: true,
-                    type: HomeSectionType.singleRowNormal
+                    type: HomeSectionType[updatedRowStyle as keyof typeof HomeSectionType]
                 }),
                 request: App.createRequest({
-                    url: tachiAPI.getBaseURL() + "/category/" + categoryId,
+                    url: (await getServerAPI(this.stateManager)) + "update/recentChapters/0",
                     method: "GET"
                 }),
-                subtitle: "",
-                type: "category"
+                responseArray: "page",
             })
         }
+        if (categoryRowState){
+            const serverCategories = await fetchServerCategories(this.stateManager, this.requestManager)
+            const selectedCategories : Array<string>= await this.stateManager.retrieve(SELECTED_CATEGORIES_KEY)
 
-        // Source Sections
-        for (const sourceId of await tachiSources.getSelectedSources(this.stateManager)) {
-            sections.push({
-                section: App.createHomeSection({
-                    id: "popular-" + sourceId,
-                    title: tachiSources.getSourceNameFromId(sourceId) + " Popular",
-                    containsMoreItems: true,
-                    type: HomeSectionType.singleRowNormal
-                }),
-                request: App.createRequest({
-                    url: tachiAPI.getBaseURL() + "/source/" + sourceId + "/popular/1",
-                    method: "GET"
-                }),
-                subtitle: tachiSources.getSourceNameFromId(sourceId as string),
-                type: "source"
-            })
-
-            if (tachiSources.getAllSources()[sourceId]["supportsLatest"]) {
+            const orderedSelectedCategories = Object.keys(serverCategories)
+            .filter((key) => selectedCategories.includes(key))
+            .sort((a,b) => {
+                const aOrder = getCategoryFromId(serverCategories, a).order
+                const bOrder = getCategoryFromId(serverCategories, b).order
+                
+                if (aOrder < bOrder){
+                    return -1
+                }
+                else if (aOrder > bOrder){
+                    return 1
+                }
+                return 0
+            }) 
+            
+            for (const categoryId of orderedSelectedCategories){
                 sections.push({
                     section: App.createHomeSection({
-                        id: "latest-" + sourceId,
-                        title: tachiSources.getSourceNameFromId(sourceId) + " Latest",
+                        id: "category-" + categoryId,
+                        title: getCategoryNameFromId(serverCategories, categoryId),
                         containsMoreItems: true,
-                        type: HomeSectionType.singleRowNormal
+                        type: HomeSectionType[categoryRowStyle as keyof typeof HomeSectionType]
                     }),
                     request: App.createRequest({
-                        url: tachiAPI.getBaseURL() + "/source/" + sourceId + "/latest/1",
+                        url: (await getServerAPI(this.stateManager)) + "category/" + categoryId,
                         method: "GET"
                     }),
-                    subtitle: tachiSources.getSourceNameFromId(sourceId as string),
-                    type: "source"
+                    responseArray: "root"
                 })
             }
         }
-        // run promises
-        for (const section of sections) {
+        if (sourceRowState){
+            const serverSources = await getServerSources(this.stateManager);
+            const selectedSources = await getSelectedSources(this.stateManager);
+            
+            for (const sourceId of selectedSources){
+                sections.push({
+                    section: App.createHomeSection({
+                        id: "popular-" + sourceId,
+                        title: getSourceNameFromId(serverSources, sourceId) + " (Popular)" ,
+                        containsMoreItems: true,
+                        type: HomeSectionType[sourceRowStyle as keyof typeof HomeSectionType]
+                    }),
+                    request: App.createRequest({
+                        url: (await getServerAPI(this.stateManager)) + "source/" + sourceId + "/popular/1",
+                        method:"GET"
+                    }),
+                    responseArray: "mangaList"
+                })
+
+                if (getSourceFromId(serverSources, sourceId).supportsLatest){
+                    sections.push({
+                        section: App.createHomeSection({
+                            id: "latest-" + sourceId,
+                            title: getSourceNameFromId(serverSources, sourceId) + " (Latest)" ,
+                            containsMoreItems: true,
+                            type: HomeSectionType[sourceRowStyle as keyof typeof HomeSectionType]
+                        }),
+                        request: App.createRequest({
+                            url: (await getServerAPI(this.stateManager)) + "source/" + sourceId + "/latest/1",
+                            method: "GET"
+                        }),
+                        responseArray: "mangaList"
+                    })
+                }
+            }
+        }
+
+        // Run Promises
+        for (const section of sections){
             sectionCallback(section.section)
 
             promises.push(
                 this.requestManager.schedule(section.request, 1).then(async response => {
                     const json = JSON.parse(response.data ?? "")
                     const tiles = []
-                    if (section.type == "update") {
 
-                        for (const manga of json.page.slice(0, 10)) {
-                            tiles.push(
-                                App.createPartialSourceManga({
-                                    title: manga.manga.title,
-                                    mangaId: manga.manga.id.toString(),
-                                    image: await tachiAPI.getServerAddress(this.stateManager) + manga.manga.thumbnailUrl,
-                                    subtitle: ""
-                                })
-                            )
-
-                        }
-                    }
-                    if (section.type == "category") {
-                        for (const manga of json.slice(0, 10)) {
-                            tiles.push(
-                                App.createPartialSourceManga({
-                                    title: manga.title,
-                                    mangaId: manga.id.toString(),
-                                    image: await tachiAPI.getServerAddress(this.stateManager) + manga.thumbnailUrl
-                                })
-                            )
-                        }
-                    }
-                    if (section.type == "source") {
-                        for (const manga of json.mangaList.slice(0, 10)) {
-                            tiles.push(
-                                App.createPartialSourceManga({
-                                    title: manga.title,
-                                    mangaId: manga.id.toString(),
-                                    image: await tachiAPI.getServerAddress(this.stateManager) + manga.thumbnailUrl,
-                                    subtitle: section.subtitle
-                                })
-                            )
-                        }
+                    let data;
+                    switch (section.responseArray) {
+                        case "page":
+                            data = json.page
+                            break
+                        case "mangaList":
+                            data = json.mangaList
+                            break;
+                        default:
+                            data = json
+                            break;
                     }
 
+                    for (const mangaResponse of data.slice(0,mangaPerRow)){
+                        let manga : tachiManga;
+                        if (section.responseArray === "page"){
+                            manga = mangaResponse.manga
+                        }
+                        else {
+                            manga = mangaResponse
+                        }  
+
+                        tiles.push(
+                            App.createPartialSourceManga({
+                                title: manga.title,
+                                mangaId: manga.id.toString(),
+                                image: (await getServerURL(this.stateManager)) + manga.thumbnailUrl.slice(1)
+                            })
+                        )
+                    }
 
                     section.section.items = tiles
                     sectionCallback(section.section)
                 })
             )
         }
-        // awit promise all
+
         await Promise.all(promises)
     }
 
-    // Handles when users click on the "more" button in the homepage.
-    // Currently only set up to work with sources
     async getViewMoreItems(homepageSectionId: string, metadata: any): Promise<PagedResults> {
         const sourceId = homepageSectionId.split('-').pop() ?? ""
         const type = homepageSectionId.split("-")[0]
-        const tachiAPI = await this.tachiAPI
-        const tachiSources = await this.tachiSources.init(this.stateManager, this.requestManager, tachiAPI)
 
-        if (tachiSources instanceof Error) {
-            throw tachiSources;
-        }
-
-        const tiles = []
-        let tileData: any;
+        const tiles = [];
         let page;
+        let apiEndpoint : any;
+        let response;
+        let tileData : any;
 
-        // Even if currentpageindex + 10 is bigger than currentpagelength, it will just cut to currentpagelength
         switch (type) {
             case "updated":
-                page = metadata?.page ?? 0;
-                tileData = await tachiAPI.makeRequest(this.requestManager, "/update/recentChapters/" + page)
-                for (const manga of tileData.page) {
-                    tiles.push(
-                        App.createPartialSourceManga({
-                            title: manga.manga.title,
-                            mangaId: manga.manga.id.toString(),
-                            image: await tachiAPI.getServerAddress(this.stateManager) + manga.manga.thumbnailUrl,
-                            subtitle: ""
-                        })
-                    )
-                }
-                break;
-            case "category":
-                page = metadata?.page ?? -1;
-                tileData = await tachiAPI.makeRequest(this.requestManager, "/category/" + sourceId)
-                for (const manga of tileData) {
-                    tiles.push(
-                        App.createPartialSourceManga({
-                            title: manga.title,
-                            mangaId: manga.id.toString(),
-                            image: await tachiAPI.getServerAddress(this.stateManager) + manga.thumbnailUrl,
-                            subtitle: ""
-                        })
-                    )
-                }
+                page = metadata?.page ?? 0
+                apiEndpoint = "update/recentChapters/" + page;
+                response = (await makeRequest(this.stateManager, this.requestManager, apiEndpoint));
+                tileData = response.page
                 break
+            case "category":
+                page = metadata?.page ?? undefined
+                apiEndpoint = "category/" + sourceId;
+                response = (await makeRequest(this.stateManager, this.requestManager, apiEndpoint));
+                tileData = response
+                break
+            case "popular":
+            case "latest":
             default:
-                page = metadata?.page ?? 1;
-                tileData = await tachiAPI.makeRequest(this.requestManager, "/source/" + sourceId + "/" + type + "/" + page)
-                for (const manga of tileData.mangaList) {
-                    tiles.push(
-                        App.createPartialSourceManga({
-                            title: manga.title,
-                            mangaId: manga.id.toString(),
-                            image: await tachiAPI.getServerAddress(this.stateManager) + manga.thumbnailUrl,
-                            subtitle: ""
-                        })
-                    )
-                }
+                page = metadata?.page ?? 1
+                apiEndpoint = "source/" + sourceId + "/" + type + "/" + page;
+                response = (await makeRequest(this.stateManager, this.requestManager, apiEndpoint));
+                tileData = response.mangaList
                 break;
         }
 
-        metadata = tileData.hasNextPage ? { page: page + 1 } : undefined
+        for (const mangaResponse of tileData){
+            let manga : tachiManga;
+            if (type === "updated"){
+                manga = mangaResponse.manga
+            }
+            else {
+                manga = mangaResponse
+            }
 
+            tiles.push(
+                App.createPartialSourceManga({
+                    title: manga.title,
+                    mangaId: manga.id.toString(),
+                    image: (await getServerURL(this.stateManager)) + manga.thumbnailUrl.slice(1)
+                })
+            )
+        }
+
+        metadata = response.hasNextPage ? { page: page + 1 } : undefined
         return App.createPagedResults({
             results: tiles,
             metadata: metadata
         })
+
     }
 
-    // Handles search
     async getSearchResults(query: SearchRequest, metadata: any): Promise<PagedResults> {
-        const tachiAPI = await this.tachiAPI
-        const tachiSources = await this.tachiSources.init(this.stateManager, this.requestManager, tachiAPI)
-
-        if (tachiSources instanceof Error) {
-            throw tachiSources;
-        }
-
-        const selectedSources = await tachiSources.getSelectedSources(this.stateManager)
+        const serverSources = await getServerSources(this.stateManager)
+        const selectedSources = await getSelectedSources(this.stateManager)
         const meta_sources: { [key: string]: boolean } = metadata?.sources ?? {}
         const page: number = metadata?.page ?? 1;
+
         const paramsList = [`pageNum=${page}`];
         if (query.title !== undefined && query.title !== "") {
             paramsList.push("searchTerm=" + encodeURIComponent(query.title));
@@ -445,18 +408,17 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
         const tiles = []
         for (const source of selectedSources) {
             if (page !== 1) {
-                if (!meta_sources[source.id]) continue
+                if (!meta_sources[source]) continue
             }
 
-            const mangaResults = await tachiAPI.makeRequest(this.requestManager, "/source/" + source + "/search" + paramsString)
-
-            for (const manga of mangaResults.mangaList) {
+            const mangaResults = await makeRequest(this.stateManager, this.requestManager, "source/" + source + "/search" + paramsString)
+            for (const manga of mangaResults.mangaList){
                 tiles.push(
                     App.createPartialSourceManga({
                         title: manga.title,
                         mangaId: String(manga.id),
-                        image: await tachiAPI.getServerAddress(this.stateManager) + manga.thumbnailUrl,
-                        subtitle: tachiSources.getSourceNameFromId(manga.sourceId)
+                        image: (await getServerURL(this.stateManager)) + manga.thumbnailUrl.slice(1),
+                        subtitle: getSourceNameFromId(serverSources, source)
                     })
                 )
             }

--- a/src/TachiDesk/TachiDesk.ts
+++ b/src/TachiDesk/TachiDesk.ts
@@ -15,13 +15,17 @@ import {
     SourceIntents,
     SourceManga,
     TagSection,
-    Request
+    Request,
+    Response
 } from "@paperback/types"
 
 import {
     HomepageSettings,
+    categoriesSettings,
+    languageSettings,
     resetSettingsButton,
     serverAddressSettings,
+    sourceSettings,
 } from "./Settings";
 
 import {
@@ -103,19 +107,17 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
 
     // Settings
     async getSourceMenu(): Promise<DUISection> {
-
-        // Checks if you need to migrate from v1
-        if (await this.stateManager.retrieve("server_address")) {
-            await v1Migration(this.stateManager)
-        }
-
         return App.createDUISection({
             id: "main",
             header: "Source Settings",
+            footer: "IMPORTANT NOTE: settings are more stable if you wait for your homepage section to load.",
             isHidden: false,
             rows: async () => [
                 serverAddressSettings(this.stateManager, this.requestManager),
                 HomepageSettings(this.stateManager, this.requestManager),
+                await categoriesSettings(this.stateManager, this.requestManager),
+                await languageSettings(this.stateManager),
+                await sourceSettings(this.stateManager, this.requestManager),
                 await resetSettingsButton(this.stateManager)
             ]
         })
@@ -202,6 +204,11 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
     async getHomePageSections(sectionCallback: (section: HomeSection) => void): Promise<void> {
         const promises: Promise<void>[] = []
         const sections = []
+
+        // Checks if you need to migrate from v1
+        if (await this.stateManager.retrieve("server_address")) {
+            await v1Migration(this.stateManager)
+        }
 
         // Error Checking here!!!
         if (await testRequest(this.stateManager, this.requestManager) instanceof Error) {

--- a/src/TachiDesk/TachiDesk.ts
+++ b/src/TachiDesk/TachiDesk.ts
@@ -230,17 +230,21 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
 
         // only fetches when url has been set, only sets the fetched when the old record is different 
         if (serverURL !== DEFAULT_SERVER_URL) {
-            fetchServerSources(this.stateManager, this.requestManager).then((response) => {
-                if (JSON.stringify(response) !== JSON.stringify(serverSources)) {
-                    setServerSources(this.stateManager, response)
-                }
-            })
+            promises.push(
+                fetchServerSources(this.stateManager, this.requestManager).then((response) => {
+                    if (JSON.stringify(response) !== JSON.stringify(serverSources)) {
+                        setServerSources(this.stateManager, response)
+                    }
+                })
+            )
 
-            fetchServerCategories(this.stateManager, this.requestManager).then((response) => {
-                if (JSON.stringify(response) !== JSON.stringify(serverCategories)) {
-                    setServerCategories(this.stateManager, response)
-                }
-            })
+            promises.push(
+                fetchServerCategories(this.stateManager, this.requestManager).then((response) => {
+                    if (JSON.stringify(response) !== JSON.stringify(serverCategories)) {
+                        setServerCategories(this.stateManager, response)
+                    }
+                })
+            )
         }
 
         // Gets the settings values to set the type of rows

--- a/src/TachiDesk/TachiDesk.ts
+++ b/src/TachiDesk/TachiDesk.ts
@@ -222,6 +222,7 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
             sectionCallback(section);
             return;
         }
+
         // Last test to ensure that we can connect to the server
         if ((await this.tachiAPI).makeRequest(this.requestManager, "/settings/about") instanceof Error) {
             const section = App.createHomeSection({
@@ -251,12 +252,21 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
             type: "update"
         })
 
+        let organized_categories = [];
+        let unorganized_categories = await tachiCategories.getSelectedCategories(this.stateManager);
+
+        for (const categoryId of tachiCategories.getAllCategoryIdsInOrder()){
+            if (unorganized_categories.includes(categoryId.toString())){
+                organized_categories.push(categoryId)
+            }
+        }
+
         // Category Sections
-        for (const categoryId of await tachiCategories.getSelectedCategories(this.stateManager)) {
+        for (const categoryId of organized_categories) {
             sections.push({
                 section: App.createHomeSection({
                     id: "category-" + categoryId,
-                    title: tachiCategories.getSelectedCategoryFromId(categoryId as string),
+                    title: tachiCategories.getSelectedCategoryFromId(categoryId.toString()),
                     containsMoreItems: false,
                     type: HomeSectionType.singleRowLarge
                 }),

--- a/src/TachiDesk/TachiDesk.ts
+++ b/src/TachiDesk/TachiDesk.ts
@@ -53,7 +53,7 @@ export const TachiDeskInfo: SourceInfo = {
     description: 'Paperback extension which aims to bridge all of Tachidesks features and the Paperback App.',
     icon: 'icon.png',
     name: 'Tachidesk',
-    version: '2.0-beta',
+    version: '2.0',
     websiteBaseURL: "https://github.com/Suwayomi/Tachidesk-Server",
     contentRating: ContentRating.ADULT,
     sourceTags: [

--- a/src/TachiDesk/TachiDesk.ts
+++ b/src/TachiDesk/TachiDesk.ts
@@ -14,7 +14,8 @@ import {
     SourceInfo,
     SourceIntents,
     SourceManga,
-    TagSection
+    TagSection,
+    Request
 } from "@paperback/types"
 
 import { 
@@ -25,6 +26,8 @@ import {
 
 import {  
     fetchServerCategories, 
+    getAuthState, 
+    getAuthString, 
     getCategoryFromId, 
     getCategoryNameFromId, 
     getCategoryRowState, 
@@ -69,7 +72,24 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
     stateManager = App.createSourceStateManager();
     requestManager = App.createRequestManager({
         requestsPerSecond: 4,
-        requestTimeout: 20000
+        requestTimeout: 20000,
+        interceptor: {
+            interceptRequest: async (request: Request) => {
+                const authEnabled = await getAuthState(this.stateManager);
+
+                if (authEnabled) {
+                    request.headers = {
+                        ...request.headers,
+                        authorization: await getAuthString(this.stateManager)
+                    }
+                }
+
+                return request
+            },
+            interceptResponse: async (response: Response): Promise<Response> => {
+                return response
+            }
+        }
     })
 
     // Variable used for share URL

--- a/src/TachiDesk/TachiDesk.ts
+++ b/src/TachiDesk/TachiDesk.ts
@@ -36,7 +36,7 @@ export const TachiDeskInfo: SourceInfo = {
     description: 'Paperback extension which aims to bridge all of Tachidesks features and the Paperback App.',
     icon: 'icon.png',
     name: 'Tachidesk',
-    version: '1.0',
+    version: '1.1',
     websiteBaseURL: "https://github.com/Suwayomi/Tachidesk-Server",
     contentRating: ContentRating.EVERYONE,
     sourceTags: [

--- a/src/TachiDesk/TachiDesk.ts
+++ b/src/TachiDesk/TachiDesk.ts
@@ -18,42 +18,42 @@ import {
     Request
 } from "@paperback/types"
 
-import { 
+import {
     HomepageSettings,
     resetSettingsButton,
     serverAddressSettings,
 } from "./Settings";
 
-import {  
+import {
     DEFAULT_SERVER_URL,
-    fetchServerCategories, 
-    fetchServerSources, 
-    getAuthState, 
-    getAuthString, 
-    getCategoryFromId, 
-    getCategoryNameFromId, 
-    getCategoryRowState, 
-    getCategoryRowStyle, 
-    getMangaPerRow, 
-    getSelectedCategories, 
-    getSelectedSources, 
-    getServerAPI, 
-    getServerCategories, 
-    getServerSources, 
-    getServerURL, 
-    getSourceFromId, 
-    getSourceNameFromId, 
-    getSourceRowState, 
-    getSourceRowStyle, 
-    getUpdatedRowState, 
-    getUpdatedRowStyle, 
-    makeRequest, 
-    serverUnavailableMangaTiles, 
-    setServerCategories, 
-    setServerSources, 
-    tachiChapter, 
+    fetchServerCategories,
+    fetchServerSources,
+    getAuthState,
+    getAuthString,
+    getCategoryFromId,
+    getCategoryNameFromId,
+    getCategoryRowState,
+    getCategoryRowStyle,
+    getMangaPerRow,
+    getSelectedCategories,
+    getSelectedSources,
+    getServerAPI,
+    getServerCategories,
+    getServerSources,
+    getServerURL,
+    getSourceFromId,
+    getSourceNameFromId,
+    getSourceRowState,
+    getSourceRowStyle,
+    getUpdatedRowState,
+    getUpdatedRowStyle,
+    makeRequest,
+    serverUnavailableMangaTiles,
+    setServerCategories,
+    setServerSources,
+    tachiChapter,
     tachiManga,
-    testRequest, 
+    testRequest,
     v1Migration
 } from "./Common";
 
@@ -103,9 +103,9 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
 
     // Settings
     async getSourceMenu(): Promise<DUISection> {
-        
+
         // Checks if you need to migrate from v1
-        if(await this.stateManager.retrieve("server_address")){
+        if (await this.stateManager.retrieve("server_address")) {
             await v1Migration(this.stateManager)
         }
 
@@ -123,7 +123,7 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
 
     // share URL
     getMangaShareUrl(mangaId: string): string {
-        if (this.serverAddress != ""){
+        if (this.serverAddress != "") {
             return this.serverAddress + "manga/" + mangaId
         }
         return ""
@@ -131,12 +131,12 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
 
     // Manga info -> uses TachiManga interface
     async getMangaDetails(mangaId: string): Promise<SourceManga> {
-        const manga : tachiManga = await makeRequest(this.stateManager, this.requestManager, "manga/" + mangaId)
-        const tags : [TagSection] = [
+        const manga: tachiManga = await makeRequest(this.stateManager, this.requestManager, "manga/" + mangaId)
+        const tags: [TagSection] = [
             App.createTagSection({
                 id: "0",
                 label: "genres",
-                tags: manga.genre.map((tag : string) => App.createTag({
+                tags: manga.genre.map((tag: string) => App.createTag({
                     id: tag,
                     label: tag
                 }))
@@ -159,12 +159,12 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
 
     // Chapter list, sets the share URl address
     async getChapters(mangaId: string): Promise<Chapter[]> {
-        const chaptersData : tachiChapter[] = await makeRequest(this.stateManager, this.requestManager, "manga/" + mangaId + "/chapters")
+        const chaptersData: tachiChapter[] = await makeRequest(this.stateManager, this.requestManager, "manga/" + mangaId + "/chapters")
         this.serverAddress = await getServerURL(this.stateManager)
 
         const chapters: Chapter[] = []
 
-        for (const chapter of chaptersData){
+        for (const chapter of chaptersData) {
             chapters.push(
                 App.createChapter({
                     id: chapter.index.toString(),
@@ -182,12 +182,12 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
     // Provides pages for chapter
     async getChapterDetails(mangaId: string, chapterId: string): Promise<ChapterDetails> {
         const apiURL = await getServerAPI(this.stateManager)
-        const chapterData : tachiChapter = await makeRequest(this.stateManager, this.requestManager, "manga/" + mangaId + "/chapter/" + chapterId)
+        const chapterData: tachiChapter = await makeRequest(this.stateManager, this.requestManager, "manga/" + mangaId + "/chapter/" + chapterId)
 
-        const pages : string[] = []
+        const pages: string[] = []
 
         // Tachidesk uses page count, so for keys makes it easy to provide the links
-        for ( const pageIndex of Array(chapterData.pageCount).keys()){
+        for (const pageIndex of Array(chapterData.pageCount).keys()) {
             pages.push(apiURL + "manga/" + mangaId + "/chapter/" + chapterId + "/page/" + pageIndex)
         }
 
@@ -202,9 +202,9 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
     async getHomePageSections(sectionCallback: (section: HomeSection) => void): Promise<void> {
         const promises: Promise<void>[] = []
         const sections = []
-        
+
         // Error Checking here!!!
-        if (await testRequest(this.stateManager, this.requestManager) instanceof Error){
+        if (await testRequest(this.stateManager, this.requestManager) instanceof Error) {
             const section = App.createHomeSection({
                 id: "unset",
                 title: "Server Error",
@@ -222,15 +222,15 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
         const serverCategories = await getServerCategories(this.stateManager);
 
         // only fetches when url has been set, only sets the fetched when the old record is different 
-        if (serverURL !== DEFAULT_SERVER_URL){
+        if (serverURL !== DEFAULT_SERVER_URL) {
             fetchServerSources(this.stateManager, this.requestManager).then((response) => {
-                if (JSON.stringify(response) !== JSON.stringify(serverSources)){
+                if (JSON.stringify(response) !== JSON.stringify(serverSources)) {
                     setServerSources(this.stateManager, response)
                 }
             })
-            
-            fetchServerCategories(this.stateManager,this.requestManager).then((response) => {
-                if(JSON.stringify(response) !== JSON.stringify(serverCategories)){
+
+            fetchServerCategories(this.stateManager, this.requestManager).then((response) => {
+                if (JSON.stringify(response) !== JSON.stringify(serverCategories)) {
                     setServerCategories(this.stateManager, response)
                 }
             })
@@ -244,9 +244,9 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
         const updatedRowStyle = (await getUpdatedRowStyle(this.stateManager))[0];
         const categoryRowStyle = (await getCategoryRowStyle(this.stateManager))[0];
         const sourceRowStyle = (await getSourceRowStyle(this.stateManager))[0];
-        
+
         // Push Sections
-        if (updatedRowState){
+        if (updatedRowState) {
             sections.push({
                 section: App.createHomeSection({
                     id: "updated",
@@ -261,27 +261,27 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
                 responseArray: "page", //Refers to array of manga being inside the response's page key
             })
         }
-        if (categoryRowState){
+        if (categoryRowState) {
             const serverCategories = await fetchServerCategories(this.stateManager, this.requestManager)
-            const selectedCategories : Array<string>= await getSelectedCategories(this.stateManager)
+            const selectedCategories: Array<string> = await getSelectedCategories(this.stateManager)
 
             // Gets the information of selected sources to compare their order on the tachidesk server
             const orderedSelectedCategories = Object.keys(serverCategories)
-            .filter((key) => selectedCategories.includes(key))
-            .sort((a,b) => {
-                const aOrder = getCategoryFromId(serverCategories, a).order
-                const bOrder = getCategoryFromId(serverCategories, b).order
-                
-                if (aOrder < bOrder){
-                    return -1
-                }
-                else if (aOrder > bOrder){
-                    return 1
-                }
-                return 0
-            }) 
-            
-            for (const categoryId of orderedSelectedCategories){
+                .filter((key) => selectedCategories.includes(key))
+                .sort((a, b) => {
+                    const aOrder = getCategoryFromId(serverCategories, a).order
+                    const bOrder = getCategoryFromId(serverCategories, b).order
+
+                    if (aOrder < bOrder) {
+                        return -1
+                    }
+                    else if (aOrder > bOrder) {
+                        return 1
+                    }
+                    return 0
+                })
+
+            for (const categoryId of orderedSelectedCategories) {
                 sections.push({
                     section: App.createHomeSection({
                         id: "category-" + categoryId,
@@ -297,31 +297,31 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
                 })
             }
         }
-        if (sourceRowState){
+        if (sourceRowState) {
             const serverSources = await getServerSources(this.stateManager);
             const selectedSources = await getSelectedSources(this.stateManager);
-            
+
             // Adds popular and latest... there might be a way to handle this better (option) but... thats a lot of sources
-            for (const sourceId of selectedSources){
+            for (const sourceId of selectedSources) {
                 sections.push({
                     section: App.createHomeSection({
                         id: "popular-" + sourceId,
-                        title: getSourceNameFromId(serverSources, sourceId) + " (Popular)" ,
+                        title: getSourceNameFromId(serverSources, sourceId) + " (Popular)",
                         containsMoreItems: true,
                         type: HomeSectionType[sourceRowStyle as keyof typeof HomeSectionType] //Converts String to HomeSectionType
                     }),
                     request: App.createRequest({
                         url: (await getServerAPI(this.stateManager)) + "source/" + sourceId + "/popular/1",
-                        method:"GET"
+                        method: "GET"
                     }),
                     responseArray: "mangaList" //Refers to array of manga being inside the response's mangaList key
                 })
 
-                if (getSourceFromId(serverSources, sourceId).supportsLatest){
+                if (getSourceFromId(serverSources, sourceId).supportsLatest) {
                     sections.push({
                         section: App.createHomeSection({
                             id: "latest-" + sourceId,
-                            title: getSourceNameFromId(serverSources, sourceId) + " (Latest)" ,
+                            title: getSourceNameFromId(serverSources, sourceId) + " (Latest)",
                             containsMoreItems: true,
                             type: HomeSectionType[sourceRowStyle as keyof typeof HomeSectionType] //Converts String to HomeSectionType
                         }),
@@ -336,7 +336,7 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
         }
 
         // Run Promises
-        for (const section of sections){
+        for (const section of sections) {
             sectionCallback(section.section)
 
             promises.push(
@@ -359,14 +359,14 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
                     }
 
                     // Cuts manga list to the first X amount of manga (from settings)
-                    for (const mangaResponse of data.slice(0,mangaPerRow)){
-                        let manga : tachiManga;
-                        if (section.responseArray === "page"){
+                    for (const mangaResponse of data.slice(0, mangaPerRow)) {
+                        let manga: tachiManga;
+                        if (section.responseArray === "page") {
                             manga = mangaResponse.manga
                         }
                         else {
                             manga = mangaResponse
-                        }  
+                        }
 
                         tiles.push(
                             App.createPartialSourceManga({
@@ -393,9 +393,9 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
 
         const tiles = [];
         let page;
-        let apiEndpoint : any;
+        let apiEndpoint: any;
         let response;
-        let tileData : any;
+        let tileData: any;
 
         // uses type of source to determine where to get the manga list and the api link
         switch (type) {
@@ -422,9 +422,9 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
         }
 
         // updated list has a manga data and chapter data so have to specify.
-        for (const mangaResponse of tileData){
-            let manga : tachiManga;
-            if (type === "updated"){
+        for (const mangaResponse of tileData) {
+            let manga: tachiManga;
+            if (type === "updated") {
                 manga = mangaResponse.manga
             }
             else {
@@ -473,7 +473,7 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
             }
 
             const mangaResults = await makeRequest(this.stateManager, this.requestManager, "source/" + source + "/search" + paramsString)
-            for (const manga of mangaResults.mangaList){
+            for (const manga of mangaResults.mangaList) {
                 tiles.push(
                     App.createPartialSourceManga({
                         title: manga.title,

--- a/src/TachiDesk/TachiDesk.ts
+++ b/src/TachiDesk/TachiDesk.ts
@@ -305,7 +305,7 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
                     const tiles = []
                     if (section.type == "update") {
 
-                        for (const manga of json.page.slice(0,10)) {
+                        for (const manga of json.page.slice(0, 10)) {
                             tiles.push(
                                 App.createPartialSourceManga({
                                     title: manga.manga.title,
@@ -318,7 +318,7 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
                         }
                     }
                     if (section.type == "category") {
-                        for (const manga of json.slice(0,10)) {
+                        for (const manga of json.slice(0, 10)) {
                             tiles.push(
                                 App.createPartialSourceManga({
                                     title: manga.title,
@@ -329,7 +329,7 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
                         }
                     }
                     if (section.type == "source") {
-                        for (const manga of json.mangaList.slice(0,10)) {
+                        for (const manga of json.mangaList.slice(0, 10)) {
                             tiles.push(
                                 App.createPartialSourceManga({
                                     title: manga.title,
@@ -364,7 +364,7 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
         }
 
         const tiles = []
-        let tileData : any;
+        let tileData: any;
         let page;
 
         // Even if currentpageindex + 10 is bigger than currentpagelength, it will just cut to currentpagelength
@@ -372,12 +372,12 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
             case "updated":
                 page = metadata?.page ?? 0;
                 tileData = await tachiAPI.makeRequest(this.requestManager, "/update/recentChapters/" + page)
-                for(const manga of tileData.page){
+                for (const manga of tileData.page) {
                     tiles.push(
                         App.createPartialSourceManga({
-                            title:manga.manga.title,
-                            mangaId:manga.manga.id.toString(),
-                            image : await tachiAPI.getServerAddress(this.stateManager) + manga.manga.thumbnailUrl,
+                            title: manga.manga.title,
+                            mangaId: manga.manga.id.toString(),
+                            image: await tachiAPI.getServerAddress(this.stateManager) + manga.manga.thumbnailUrl,
                             subtitle: ""
                         })
                     )
@@ -386,12 +386,12 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
             case "category":
                 page = metadata?.page ?? -1;
                 tileData = await tachiAPI.makeRequest(this.requestManager, "/category/" + sourceId)
-                for(const manga of tileData){
+                for (const manga of tileData) {
                     tiles.push(
                         App.createPartialSourceManga({
                             title: manga.title,
                             mangaId: manga.id.toString(),
-                            image : await tachiAPI.getServerAddress(this.stateManager) + manga.thumbnailUrl,
+                            image: await tachiAPI.getServerAddress(this.stateManager) + manga.thumbnailUrl,
                             subtitle: ""
                         })
                     )
@@ -400,12 +400,12 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
             default:
                 page = metadata?.page ?? 1;
                 tileData = await tachiAPI.makeRequest(this.requestManager, "/source/" + sourceId + "/" + type + "/" + page)
-                for(const manga of tileData.mangaList){
+                for (const manga of tileData.mangaList) {
                     tiles.push(
                         App.createPartialSourceManga({
                             title: manga.title,
                             mangaId: manga.id.toString(),
-                            image : await tachiAPI.getServerAddress(this.stateManager) + manga.thumbnailUrl,
+                            image: await tachiAPI.getServerAddress(this.stateManager) + manga.thumbnailUrl,
                             subtitle: ""
                         })
                     )
@@ -413,7 +413,7 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
                 break;
         }
 
-        metadata = tileData.hasNextPage ? { page: page + 1 } : undefined 
+        metadata = tileData.hasNextPage ? { page: page + 1 } : undefined
 
         return App.createPagedResults({
             results: tiles,


### PR DESCRIPTION
In v1.1 I made all the home sections into normal rows, fixed the reset button, limited the number of home section manga per row to 10, and added pagination to all section types (previously it was only supported by the source section).

V2.0
* New codebase because I do not value my time. Real reason is that the common classes made settings clunkier, sometimes needing an app re-launch for some changes to appear.
   * This codebase plays a lot nicer with settings.  replaces the classes with a bunch of getters and setter.
* Continued the trend of having variables for the statemanager keys and defaults, this time having a lot more key variables due to the huge boost in settings.
* Settings re-haul
   * Basic authorization support
   * Added option for manga per row limit
   * Added home section options
      * Each section type can be toggled
      * Each section type can be styled 
   * Added a "languages" selection to filter out sources
   * Fixed bug where old options stop getting displayed, making it impossible for user to unselect the option.
* Categories are sorted again (with no bugs this time.. i think..)