### PR TITLE
Set server sources and categories on submit

### DIFF
--- a/src/TachiDesk/Common.ts
+++ b/src/TachiDesk/Common.ts
@@ -234,9 +234,15 @@ export async function resetSettings(stateManager: SourceStateManager) {
 
 // ! Server URL start
 
-export async function setServerURL(stateManager: SourceStateManager, url: string) {
-    url = url == "" ? DEFAULT_SERVER_URL : url
-    url = url.slice(-1) === '/' ? url : url + "/" // Verified / at the end of URL
+export async function setServerURL(stateManager: SourceStateManager, url: string, typed = false) {
+    // * since every key press is a value set() and get(), the override which ensuring that the URL always has a backslash won't let people delete it
+    // ! typed is a boolean that we set to true only when being entered by the DUIInputField, skipping the override when typing the url
+    // ! atleast until user hits submit.
+    if (!typed) {
+        url = url == "" ? DEFAULT_SERVER_URL : url
+        url = url.slice(-1) === '/' ? url : url + "/" // Verified / at the end of URL
+    }
+
     await stateManager.store(SERVER_URL_KEY, url)
     await stateManager.store(SERVER_API_KEY, url + DEFAULT_API_ENDPOINT)
 }
@@ -352,6 +358,10 @@ export async function fetchServerCategories(stateManager: SourceStateManager, re
     let categories: Record<string, tachiCategory> = {};
 
     const fetchedCategories = await makeRequest(stateManager, requestManager, "category/");
+
+    if (fetchedCategories instanceof Error) {
+        throw new Error("Failed to fetch categories.")
+    }
     fetchedCategories.forEach((category: tachiCategory) => {
         categories[JSON.stringify(category.id)] = category
     });
@@ -407,6 +417,11 @@ export async function fetchServerSources(stateManager: SourceStateManager, reque
     let sources: Record<string, tachiSources> = {};
 
     const fetchedSources = await makeRequest(stateManager, requestManager, "source/list")
+
+    if (fetchedSources instanceof Error) {
+        throw new Error("Failed to fetch sources.")
+    }
+
     fetchedSources.forEach((source: tachiSources) => {
         sources[source.id] = source
     });

--- a/src/TachiDesk/Settings.ts
+++ b/src/TachiDesk/Settings.ts
@@ -57,14 +57,16 @@ import {
 
 // 2 Sections 1 page, -> 1 for server url, another for auth
 export const serverAddressSettings = (stateManager: SourceStateManager, requestManager: RequestManager): DUINavigationButton => {
-    // Label that shows test response
-    let label = "Click on the button!"
-
     return App.createDUINavigationButton({
         id: "serverSettings",
         label: "Server Settings",
         form: App.createDUIForm({
+            onSubmit: async () => {
+                await setServerSources(stateManager, await fetchServerSources(stateManager, requestManager));
+                await setServerCategories(stateManager, await fetchServerCategories(stateManager, requestManager));
+            },
             sections: async () => {
+                let testResults = "Click on the button!"
                 return [
                     App.createDUISection({
                         id: "urlSection",
@@ -80,8 +82,6 @@ export const serverAddressSettings = (stateManager: SourceStateManager, requestM
                                     },
                                     async set(newValue) {
                                         await setServerURL(stateManager, newValue)
-                                        await setServerSources(stateManager, await fetchServerSources(stateManager, requestManager))
-                                        await setServerCategories(stateManager, await fetchServerCategories(stateManager, requestManager))
                                     }
                                 })
                             }),
@@ -89,13 +89,19 @@ export const serverAddressSettings = (stateManager: SourceStateManager, requestM
                                 id: "testServerButton",
                                 label: "Test Server",
                                 onTap: async () => {
+                                    console.log('Testing server');
                                     const value = await testRequest(stateManager, requestManager)
-                                    label = value instanceof Error ? value.message : JSON.stringify(value)
+                                    if (value instanceof Error) {
+                                      testResults = `Error: ${value.message}`;
+                                    } else {
+                                      testResults =`Response: ${JSON.stringify(value)}`;
+                                    }
+                                    console.log(`Test results: ${testResults}`)
                                 }
                             }),
                             App.createDUILabel({
                                 id: "test_label",
-                                label: label,
+                                label: testResults,
                             })
                         ]
                     }),

--- a/src/TachiDesk/Settings.ts
+++ b/src/TachiDesk/Settings.ts
@@ -62,8 +62,16 @@ export const serverAddressSettings = (stateManager: SourceStateManager, requestM
         label: "Server Settings",
         form: App.createDUIForm({
             onSubmit: async () => {
-                await setServerSources(stateManager, await fetchServerSources(stateManager, requestManager));
-                await setServerCategories(stateManager, await fetchServerCategories(stateManager, requestManager));
+                await setServerURL(stateManager, await getServerURL(stateManager), false)
+                const serverSources = await fetchServerSources(stateManager, requestManager)
+                const serverCategories = await fetchServerCategories(stateManager, requestManager)
+                if (serverSources instanceof Error || serverCategories instanceof Error) {
+                    throw new Error("Failed to fetch server. Try again?")
+                }
+                else {
+                    await setServerSources(stateManager, serverSources);
+                    await setServerCategories(stateManager, serverCategories);
+                }
             },
             sections: async () => {
                 let testResults = "Click on the button!"
@@ -81,7 +89,7 @@ export const serverAddressSettings = (stateManager: SourceStateManager, requestM
                                         return await getServerURL(stateManager)
                                     },
                                     async set(newValue) {
-                                        await setServerURL(stateManager, newValue)
+                                        await setServerURL(stateManager, newValue, true)
                                     }
                                 })
                             }),
@@ -92,9 +100,9 @@ export const serverAddressSettings = (stateManager: SourceStateManager, requestM
                                     console.log('Testing server');
                                     const value = await testRequest(stateManager, requestManager)
                                     if (value instanceof Error) {
-                                      testResults = `Error: ${value.message}`;
+                                        testResults = `Error: ${value.message}`;
                                     } else {
-                                      testResults =`Response: ${JSON.stringify(value)}`;
+                                        testResults = `Response: ${JSON.stringify(value)}`;
                                     }
                                     console.log(`Test results: ${testResults}`)
                                 }

--- a/src/TachiDesk/TachiDesk.ts
+++ b/src/TachiDesk/TachiDesk.ts
@@ -168,7 +168,7 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
 
         // If last fetched is older than a day ago, do an online fetch for the manga and the chapter list
         // Online fetch manga to update the manga.lastFetchedAt. Seems redundant but now idea how to improve
-        if (manga.lastFetchedAt < Math.floor(Date.now() / 1000) - 86400){
+        if (manga.lastFetchedAt < Math.floor(Date.now() / 1000) - 86400) {
             makeRequest(this.stateManager, this.requestManager, "manga/" + mangaId + "?onlineFetch=true")
             chaptersQueryString += "?onlineFetch=true"
         }
@@ -507,7 +507,7 @@ export class TachiDesk implements HomePageSectionsProviding, ChapterProviding, S
 
             // If request result is an error (evaluated by makeRequest), then skip source
             // This stops individual sources from messing up the whole search process.
-            if (mangaResults instanceof Error){
+            if (mangaResults instanceof Error) {
                 continue
             }
 


### PR DESCRIPTION
Previously the API was being queried for every key-press that modified the URL. Instead, only update the serverSources/serverCategories on submit.