### PR TITLE
fix: call fetchSourceManga as a mutation so browsing and search work again

### DIFF
--- a/src/TachiDesk/TachiDesk.ts
+++ b/src/TachiDesk/TachiDesk.ts
@@ -201,7 +201,7 @@ const GQL_GET_CATEGORY_MANGAS = `
 `;
 
 const GQL_GET_SOURCE_MANGAS = `
-    query GetSourceMangas($sourceId: LongString!, $type: FetchSourceMangaType!, $page: Int!) {
+    mutation GetSourceMangas($sourceId: LongString!, $type: FetchSourceMangaType!, $page: Int!) {
         fetchSourceManga(input: { source: $sourceId, type: $type, page: $page }) {
             hasNextPage
             mangas {
@@ -214,7 +214,7 @@ const GQL_GET_SOURCE_MANGAS = `
 `;
 
 const GQL_SEARCH_SOURCE = `
-    query SearchSource($sourceId: LongString!, $query: String, $page: Int!) {
+    mutation SearchSource($sourceId: LongString!, $query: String, $page: Int!) {
         fetchSourceManga(input: { source: $sourceId, type: SEARCH, page: $page, query: $query }) {
             hasNextPage
             mangas {


### PR DESCRIPTION
## Problem

On current Suwayomi-Server releases the extension can no longer browse a source homepage or search — both return nothing. The server responds to the browse/search GraphQL request with:

```
Validation error (FieldUndefined@[fetchSourceManga]) :
Field 'fetchSourceManga' in type 'Query' is undefined
```

## Root cause

Suwayomi-Server moved `fetchSourceManga` from the `Query` type to the `Mutation` type in its 2.x GraphQL schema. The extension still declares the two operations that use it — `GQL_GET_SOURCE_MANGAS` and `GQL_SEARCH_SOURCE` — as `query`, so the server rejects them as referencing an undefined `Query` field.

The other `fetch*` operations (`fetchManga`, `fetchChapters`, `fetchChapterPages`) are already declared as mutations, which is why only source browsing and search break while opening a manga / loading chapters still works.

## Fix

Change only those two operations from `query` to `mutation`. Nothing else is needed: the request layer (`graphqlRequest`) posts the operation string verbatim, so the operation type in the document is the only thing that has to match the schema.

```diff
-    query GetSourceMangas(...) {
+    mutation GetSourceMangas(...) {

-    query SearchSource(...) {
+    mutation SearchSource(...) {
```

## Verification

Tested against **Suwayomi-Server v2.2.2100 (r2100)**:

- Introspection confirms `fetchSourceManga` exists on `Mutation`, not `Query`.
- The same browse request that fails as a `query` returns the expected `{ hasNextPage, mangas[] }` payload when sent as a `mutation`.
- `npx paperback bundle` builds successfully.
- The bundled extension was deployed and installed in Paperback against a live v2.2.2100 server: browsing sources and search both work again.